### PR TITLE
Start work on C binding generation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 
 [compat]
 julia = "1.6"
+aws_c_common_jll = "0.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -1,0 +1,177 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.10.2"
+manifest_format = "2.0"
+project_hash = "f24c2e7b2cb562eee7914bfc548594754031b6f4"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.CEnum]]
+git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.5.0"
+
+[[deps.Clang]]
+deps = ["CEnum", "Clang_jll", "Downloads", "Pkg", "TOML"]
+git-tree-sha1 = "846054622cb22aa63b5d51b5d84ec04b42d4d587"
+uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+version = "0.17.8"
+
+[[deps.Clang_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "TOML", "Zlib_jll", "libLLVM_jll"]
+git-tree-sha1 = "de2204d98741f57e7ddb9a6a738db74ba8a608cb"
+uuid = "0ee61d77-7f21-5576-8119-9fcc46b10100"
+version = "15.0.7+10"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.5.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.4.0+0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+1"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.1.10"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.10.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.3"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
+
+[[deps.aws_c_common_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "3cbdb09867f78386555469ddecaf276ff327936a"
+uuid = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
+version = "0.9.3+1"
+
+[[deps.libLLVM_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
+version = "15.0.7+10"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.52.0+1"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+2"

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
+
+[compat]
+Clang = "0.17"
+aws_c_common_jll = "0.9"

--- a/gen/generate.jl
+++ b/gen/generate.jl
@@ -1,0 +1,18 @@
+using Clang.Generators
+using aws_c_common_jll
+
+cd(@__DIR__)
+
+include_dir = normpath(aws_c_common_jll.artifact_dir, "include", "aws", "common")
+
+options = load_options(joinpath(@__DIR__, "generator.toml"))
+
+args = get_default_args()
+
+headers = filter!(x -> endswith(x, ".h"), readdir(include_dir; join=true, sort=true))
+
+# create context
+ctx = create_context(headers, args, options)
+
+# run generator
+build!(ctx)

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -1,0 +1,26 @@
+[general]
+library_name = "libaws_c_common"
+output_file_path = "../src/lib.jl"
+jll_pkg_name = "aws_c_common_jll"
+smart_de_anonymize = true
+extract_c_comment_style = "doxygen"
+print_using_CEnum = true
+use_julia_native_enum_type = false
+print_enum_as_integer = false
+use_deterministic_symbol = true
+output_ignorelist = [
+    "AWS_RESTRICT",
+    "AWS_THREAD_LOCAL",
+    "SIZE_MAX_POWER_OF_TWO",
+    "AWS_COMMON_MATH_API",
+    "AWS_THREAD_ONCE_STATIC_INIT",
+    "AWS_BUS_ADDRESS_ALL",
+]
+auto_mutability = false
+auto_mutability_with_new = false
+show_c_function_prototype = true
+
+[codegen]
+use_julia_bool = true
+use_ccall_macro = true
+opaque_func_arg_as_PtrCvoid = true

--- a/src/lib.jl
+++ b/src/lib.jl
@@ -1,0 +1,491 @@
+using aws_c_common_jll
+export aws_c_common_jll
+
+using CEnum
+
+const __darwin_time_t = Clong
+
+struct __darwin_pthread_handler_rec
+    __routine::Ptr{Cvoid}
+    __arg::Ptr{Cvoid}
+    __next::Ptr{__darwin_pthread_handler_rec}
+end
+
+struct _opaque_pthread_once_t
+    __sig::Clong
+    __opaque::NTuple{8, Cchar}
+end
+
+struct _opaque_pthread_rwlock_t
+    __sig::Clong
+    __opaque::NTuple{192, Cchar}
+end
+
+struct _opaque_pthread_t
+    __sig::Clong
+    __cleanup_stack::Ptr{__darwin_pthread_handler_rec}
+    __opaque::NTuple{8176, Cchar}
+end
+
+const __darwin_pthread_once_t = _opaque_pthread_once_t
+
+const __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t
+
+const __darwin_pthread_t = Ptr{_opaque_pthread_t}
+
+const time_t = __darwin_time_t
+
+const pthread_once_t = __darwin_pthread_once_t
+
+const pthread_rwlock_t = __darwin_pthread_rwlock_t
+
+const pthread_t = __darwin_pthread_t
+
+struct aws_allocator
+    mem_acquire::Ptr{Cvoid}
+    mem_release::Ptr{Cvoid}
+    mem_realloc::Ptr{Cvoid}
+    mem_calloc::Ptr{Cvoid}
+    impl::Ptr{Cvoid}
+end
+
+"""
+    aws_default_allocator()
+
+### Prototype
+```c
+AWS_COMMON_API struct aws_allocator *aws_default_allocator(void);
+```
+"""
+function aws_default_allocator()
+    @ccall libaws_c_common.aws_default_allocator()::Ptr{Cint}
+end
+
+mutable struct __CFAllocator end
+
+const CFAllocatorRef = Ptr{__CFAllocator}
+
+"""
+    aws_wrapped_cf_allocator_destroy(allocator)
+
+### Prototype
+```c
+AWS_COMMON_API void aws_wrapped_cf_allocator_destroy(CFAllocatorRef allocator);
+```
+"""
+function aws_wrapped_cf_allocator_destroy(allocator)
+    @ccall libaws_c_common.aws_wrapped_cf_allocator_destroy(allocator::CFAllocatorRef)::Cint
+end
+
+"""
+    aws_mem_acquire(allocator, size)
+
+### Prototype
+```c
+AWS_COMMON_API void *aws_mem_acquire(struct aws_allocator *allocator, size_t size);
+```
+"""
+function aws_mem_acquire(allocator, size)
+    @ccall libaws_c_common.aws_mem_acquire(allocator::Ptr{aws_allocator}, size::Cint)::Ptr{Cint}
+end
+
+"""
+    aws_mem_calloc(allocator, num, size)
+
+### Prototype
+```c
+AWS_COMMON_API void *aws_mem_calloc(struct aws_allocator *allocator, size_t num, size_t size);
+```
+"""
+function aws_mem_calloc(allocator, num, size)
+    @ccall libaws_c_common.aws_mem_calloc(allocator::Ptr{aws_allocator}, num::Cint, size::Cint)::Ptr{Cint}
+end
+
+"""
+    aws_mem_release(allocator, ptr)
+
+### Prototype
+```c
+AWS_COMMON_API void aws_mem_release(struct aws_allocator *allocator, void *ptr);
+```
+"""
+function aws_mem_release(allocator, ptr)
+    @ccall libaws_c_common.aws_mem_release(allocator::Ptr{aws_allocator}, ptr::Ptr{Cvoid})::Cint
+end
+
+"""
+    aws_mem_realloc(allocator, ptr, oldsize, newsize)
+
+### Prototype
+```c
+AWS_COMMON_API int aws_mem_realloc(struct aws_allocator *allocator, void **ptr, size_t oldsize, size_t newsize);
+```
+"""
+function aws_mem_realloc(allocator, ptr, oldsize, newsize)
+    @ccall libaws_c_common.aws_mem_realloc(allocator::Ptr{aws_allocator}, ptr::Ptr{Ptr{Cvoid}}, oldsize::Cint, newsize::Cint)::Cint
+end
+
+@cenum aws_mem_trace_level::UInt32 begin
+    AWS_MEMTRACE_NONE = 0
+    AWS_MEMTRACE_BYTES = 1
+    AWS_MEMTRACE_STACKS = 2
+end
+
+"""
+    aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+### Prototype
+```c
+AWS_COMMON_API struct aws_allocator *aws_mem_tracer_new( struct aws_allocator *allocator, struct aws_allocator *deprecated, enum aws_mem_trace_level level, size_t frames_per_stack);
+```
+"""
+function aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+    @ccall libaws_c_common.aws_mem_tracer_new(allocator::Ptr{aws_allocator}, deprecated::Ptr{aws_allocator}, level::aws_mem_trace_level, frames_per_stack::Cint)::Ptr{Cint}
+end
+
+"""
+    aws_mem_tracer_destroy(trace_allocator)
+
+### Prototype
+```c
+AWS_COMMON_API struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
+```
+"""
+function aws_mem_tracer_destroy(trace_allocator)
+    @ccall libaws_c_common.aws_mem_tracer_destroy(trace_allocator::Ptr{aws_allocator})::Ptr{Cint}
+end
+
+"""
+    aws_mem_tracer_dump(trace_allocator)
+
+### Prototype
+```c
+AWS_COMMON_API void aws_mem_tracer_dump(struct aws_allocator *trace_allocator);
+```
+"""
+function aws_mem_tracer_dump(trace_allocator)
+    @ccall libaws_c_common.aws_mem_tracer_dump(trace_allocator::Ptr{aws_allocator})::Cint
+end
+
+"""
+    aws_small_block_allocator_new(allocator, multi_threaded)
+
+### Prototype
+```c
+AWS_COMMON_API struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
+```
+"""
+function aws_small_block_allocator_new(allocator, multi_threaded)
+    @ccall libaws_c_common.aws_small_block_allocator_new(allocator::Ptr{aws_allocator}, multi_threaded::Cint)::Ptr{Cint}
+end
+
+"""
+    aws_small_block_allocator_destroy(sba_allocator)
+
+### Prototype
+```c
+AWS_COMMON_API void aws_small_block_allocator_destroy(struct aws_allocator *sba_allocator);
+```
+"""
+function aws_small_block_allocator_destroy(sba_allocator)
+    @ccall libaws_c_common.aws_small_block_allocator_destroy(sba_allocator::Ptr{aws_allocator})::Cint
+end
+
+@cenum __JL_Ctag_6::UInt32 begin
+    AWS_ARRAY_LIST_DEBUG_FILL = 221
+end
+
+struct aws_array_list
+    alloc::Ptr{aws_allocator}
+    current_size::Csize_t
+    length::Csize_t
+    item_size::Csize_t
+    data::Ptr{Cvoid}
+end
+
+# typedef int ( aws_array_list_comparator_fn ) ( const void * a , const void * b )
+"""
+Prototype for a comparator function for sorting elements.
+
+a and b should be cast to pointers to the element type held in the list before being dereferenced. The function should compare the elements and return a positive number if a > b, zero if a = b, and a negative number if a < b.
+"""
+const aws_array_list_comparator_fn = Cvoid
+
+"""
+    aws_array_list_init_dynamic(AWS_RESTRICT_)
+
+Initializes an array list with an array of size initial\\_item\\_allocation * item\\_size. In this mode, the array size will grow by a factor of 2 upon insertion if space is not available. initial\\_item\\_allocation is the number of elements you want space allocated for. item\\_size is the size of each element in bytes. Mixing items types is not supported by this API.
+
+### Prototype
+```c
+int aws_array_list_init_dynamic( struct aws_array_list *AWS_RESTRICT list, struct aws_allocator *alloc, size_t initial_item_allocation, size_t item_size);
+```
+"""
+function aws_array_list_init_dynamic(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_init_dynamic(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_init_static(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL void aws_array_list_init_static( struct aws_array_list *AWS_RESTRICT list, void *raw_array, size_t item_count, size_t item_size);
+```
+"""
+function aws_array_list_init_static(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_init_static(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_init_static_from_initialized(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL void aws_array_list_init_static_from_initialized( struct aws_array_list *AWS_RESTRICT list, void *raw_array, size_t item_count, size_t item_size);
+```
+"""
+function aws_array_list_init_static_from_initialized(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_init_static_from_initialized(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_clean_up(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL void aws_array_list_clean_up(struct aws_array_list *AWS_RESTRICT list);
+```
+"""
+function aws_array_list_clean_up(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_clean_up(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_clean_up_secure(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL void aws_array_list_clean_up_secure(struct aws_array_list *AWS_RESTRICT list);
+```
+"""
+function aws_array_list_clean_up_secure(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_clean_up_secure(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_push_back(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_array_list_push_back(struct aws_array_list *AWS_RESTRICT list, const void *val);
+```
+"""
+function aws_array_list_push_back(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_push_back(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_front(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_array_list_front(const struct aws_array_list *AWS_RESTRICT list, void *val);
+```
+"""
+function aws_array_list_front(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_front(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_push_front(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_array_list_push_front(struct aws_array_list *AWS_RESTRICT list, const void *val);
+```
+"""
+function aws_array_list_push_front(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_push_front(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_pop_front(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_array_list_pop_front(struct aws_array_list *AWS_RESTRICT list);
+```
+"""
+function aws_array_list_pop_front(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_pop_front(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_pop_front_n(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL void aws_array_list_pop_front_n(struct aws_array_list *AWS_RESTRICT list, size_t n);
+```
+"""
+function aws_array_list_pop_front_n(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_pop_front_n(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_erase(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_array_list_erase(struct aws_array_list *AWS_RESTRICT list, size_t index);
+```
+"""
+function aws_array_list_erase(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_erase(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_back(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_array_list_back(const struct aws_array_list *AWS_RESTRICT list, void *val);
+```
+"""
+function aws_array_list_back(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_back(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_pop_back(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_array_list_pop_back(struct aws_array_list *AWS_RESTRICT list);
+```
+"""
+function aws_array_list_pop_back(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_pop_back(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_clear(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL void aws_array_list_clear(struct aws_array_list *AWS_RESTRICT list);
+```
+"""
+function aws_array_list_clear(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_clear(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_shrink_to_fit(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_COMMON_API int aws_array_list_shrink_to_fit(struct aws_array_list *AWS_RESTRICT list);
+```
+"""
+function aws_array_list_shrink_to_fit(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_shrink_to_fit(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_copy(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_COMMON_API int aws_array_list_copy(const struct aws_array_list *AWS_RESTRICT from, struct aws_array_list *AWS_RESTRICT to);
+```
+"""
+function aws_array_list_copy(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_copy(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_swap_contents(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL void aws_array_list_swap_contents( struct aws_array_list *AWS_RESTRICT list_a, struct aws_array_list *AWS_RESTRICT list_b);
+```
+"""
+function aws_array_list_swap_contents(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_swap_contents(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_get_at(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_array_list_get_at(const struct aws_array_list *AWS_RESTRICT list, void *val, size_t index);
+```
+"""
+function aws_array_list_get_at(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_get_at(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_get_at_ptr(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_array_list_get_at_ptr(const struct aws_array_list *AWS_RESTRICT list, void **val, size_t index);
+```
+"""
+function aws_array_list_get_at_ptr(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_get_at_ptr(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_ensure_capacity(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_COMMON_API int aws_array_list_ensure_capacity(struct aws_array_list *AWS_RESTRICT list, size_t index);
+```
+"""
+function aws_array_list_ensure_capacity(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_ensure_capacity(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_set_at(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_array_list_set_at(struct aws_array_list *AWS_RESTRICT list, const void *val, size_t index);
+```
+"""
+function aws_array_list_set_at(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_set_at(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_swap(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_COMMON_API void aws_array_list_swap(struct aws_array_list *AWS_RESTRICT list, size_t a, size_t b);
+```
+"""
+function aws_array_list_swap(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_swap(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+
+"""
+    aws_array_list_sort(AWS_RESTRICT_)
+
+### Prototype
+```c
+AWS_COMMON_API void aws_array_list_sort(struct aws_array_list *AWS_RESTRICT list, aws_array_list_comparator_fn *compare_fn);
+```
+"""
+function aws_array_list_sort(AWS_RESTRICT_)
+    @ccall libaws_c_common.aws_array_list_sort(AWS_RESTRICT_::Ptr{aws_array_list})::Cint
+end
+


### PR DESCRIPTION
Just a start, but I'm running into the following error when generating:
```julia
[ Info: Emit Julia expressions...
[ Info: [ProloguePrinter]: print to ../src/lib.jl
[ Info: [GeneralPrinter]: print to ../src/lib.jl
ERROR: LoadError: AssertionError: ptr_ref[] != C_NULL
Stacktrace:
  [1] TokenList
    @ ~/.julia/packages/Clang/kNxXb/src/token.jl:13 [inlined]
  [2] tokenize(c::Clang.CLTypedefDecl)
    @ Clang ~/.julia/packages/Clang/kNxXb/src/token.jl:105
  [3] pretty_print(io::IOStream, node::ExprNode{Clang.Generators.TypedefFunction, Clang.CLTypedefDecl}, options::Dict{String, Any})
    @ Clang.Generators ~/.julia/packages/Clang/kNxXb/src/generator/print.jl:75
  [4] (::Clang.Generators.var"#140#141"{ExprDAG, Dict{String, Any}, Nothing, Vector{String}, Dict{String, Any}})(io::IOStream)
    @ Clang.Generators ~/.julia/packages/Clang/kNxXb/src/generator/passes.jl:1015
  [5] open(::Clang.Generators.var"#140#141"{ExprDAG, Dict{…}, Nothing, Vector{…}, Dict{…}}, ::String, ::Vararg{String}; kwargs::@Kwargs{})
    @ Base ./io.jl:396
  [6] open(::Function, ::String, ::String)
    @ Base ./io.jl:393
  [7] (::GeneralPrinter)(dag::ExprDAG, options::Dict{String, Any})
    @ Clang.Generators ~/.julia/packages/Clang/kNxXb/src/generator/passes.jl:1011
  [8] build!(ctx::Context, stage::Clang.Generators.BuildStage)
    @ Clang.Generators ~/.julia/packages/Clang/kNxXb/src/generator/context.jl:176
  [9] build!(ctx::Context)
    @ Clang.Generators ~/.julia/packages/Clang/kNxXb/src/generator/context.jl:167
 [10] top-level scope
    @ ~/.julia/dev/LibAwsCommon/gen/generate.jl:18
 [11] include(fname::String)
    @ Base.MainInclude ./client.jl:489
 [12] top-level scope
    @ REPL[2]:1
in expression starting at /Users/jacob.quinn/.julia/dev/LibAwsCommon/gen/generate.jl:18
Some type information was truncated. Use `show(err)` to see complete types.
```