### PR TITLE
Adjust generated code to work better with cross-references and be more complete

### DIFF
--- a/.github/workflows/generate_bindings.yml
+++ b/.github/workflows/generate_bindings.yml
@@ -29,9 +29,20 @@ jobs:
       - name: Run the generator
         run: ./gen/generate.sh
 
-      - name: Create Pull Request
+      - name: Create Pull Request (on push)
         uses: peter-evans/create-pull-request@v6
         with:
+          commit-message: "Regenerate bindings"
+          title: "Regenerate bindings"
+          reviewers: |
+            quinnj
+            Octogonapus
+
+      - name: Create Pull Request (on PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: ${{ github.head_ref }}
           commit-message: "Regenerate bindings"
           title: "Regenerate bindings"
           reviewers: |

--- a/.github/workflows/generate_bindings.yml
+++ b/.github/workflows/generate_bindings.yml
@@ -30,6 +30,7 @@ jobs:
         run: ./gen/generate.sh
 
       - name: Create Pull Request (on push)
+        if: ${{ github.event_name == 'push' }}
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "Regenerate bindings"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,8 @@ makedocs(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://github.com/JuliaServices/LibAwsCommon.jl",
         assets=String[],
+        size_threshold=2_000_000, # 2 MB, we generate about 1 MB page
+        size_threshold_warn=2_000_000,
     ),
     pages=["Home" => "index.md"],
 )

--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.2"
 manifest_format = "2.0"
-project_hash = "31f1f96877f58f98ee3e7f6c9d85e9a0481cef80"
+project_hash = "981bed63f0072e15b9d8cfedf2a309eaddd66050"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -21,9 +21,9 @@ version = "0.5.0"
 
 [[deps.Clang]]
 deps = ["CEnum", "Clang_jll", "Downloads", "Pkg", "TOML"]
-git-tree-sha1 = "cc5bcd0b7a373e59a0c4d754276c074733471c98"
+git-tree-sha1 = "2397d5da17ba4970f772a9888b208a0a1d77eb5d"
 uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
-version = "0.18.2"
+version = "0.18.3"
 
 [[deps.Clang_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "TOML", "Zlib_jll", "libLLVM_jll"]

--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.2"
 manifest_format = "2.0"
-project_hash = "17529965341e648e57dcbc863dd11933859fd679"
+project_hash = "31f1f96877f58f98ee3e7f6c9d85e9a0481cef80"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -21,9 +21,9 @@ version = "0.5.0"
 
 [[deps.Clang]]
 deps = ["CEnum", "Clang_jll", "Downloads", "Pkg", "TOML"]
-git-tree-sha1 = "846054622cb22aa63b5d51b5d84ec04b42d4d587"
+git-tree-sha1 = "cc5bcd0b7a373e59a0c4d754276c074733471c98"
 uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
-version = "0.17.8"
+version = "0.18.2"
 
 [[deps.Clang_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "TOML", "Zlib_jll", "libLLVM_jll"]
@@ -57,9 +57,9 @@ version = "1.3.1"
 
 [[deps.Git_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "12945451c5d0e2d0dca0724c3a8d6448b46bbdf9"
+git-tree-sha1 = "d18fb8a1f3609361ebda9bf029b60fd0f120c809"
 uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
-version = "2.44.0+1"
+version = "2.44.0+2"
 
 [[deps.HistoricalStdlibVersions]]
 git-tree-sha1 = "c8b04a26eaa706b4da6968dfc27ae2d030547cba"

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -4,6 +4,6 @@ JLLPrefixes = "afc68a34-7891-4c5a-9da1-1c62935e7b0d"
 aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 
 [compat]
-Clang = "0.18.2"
+Clang = "0.18.3"
 JLLPrefixes = "0.3"
 aws_c_common_jll = "=0.9.14"

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -4,6 +4,6 @@ JLLPrefixes = "afc68a34-7891-4c5a-9da1-1c62935e7b0d"
 aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 
 [compat]
-Clang = "0.17"
+Clang = "0.18.2"
 JLLPrefixes = "0.3"
 aws_c_common_jll = "=0.9.14"

--- a/gen/generate.sh
+++ b/gen/generate.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 dir=$(dirname "$0")
 julia --project="$dir" -e 'using Pkg; Pkg.instantiate()'
-julia --project="$dir" "$dir/generator.jl"
+julia --project="$dir" -t auto "$dir/generator.jl"

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -70,9 +70,21 @@ function get_docs(node, docs)
     return docs
 end
 
+function should_skip_target(target)
+    # aws_c_common_jll does not support i686 windows https://github.com/JuliaPackaging/Yggdrasil/blob/bbab3a916ae5543902b025a4a873cf9ee4a7de68/A/aws_c_common/build_tarballs.jl#L48-L49
+    return target == "i686-w64-mingw32"
+end
+
+# download toolchains in parallel
+Threads.@threads for target in JLLEnvs.JLL_ENV_TRIPLES
+    if should_skip_target(target)
+        continue
+    end
+    get_default_args(target) # downloads the toolchain
+end
+
 for target in JLLEnvs.JLL_ENV_TRIPLES
-    if target == "i686-w64-mingw32"
-        # aws_c_common_jll does not support i686 windows https://github.com/JuliaPackaging/Yggdrasil/blob/bbab3a916ae5543902b025a4a873cf9ee4a7de68/A/aws_c_common/build_tarballs.jl#L48-L49
+    if should_skip_target(target)
         continue
     end
     options = load_options(joinpath(@__DIR__, "generator.toml"))

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -5,32 +5,69 @@ import aws_c_common_jll
 
 cd(@__DIR__)
 
-function remove_itt_symbols!(dag::ExprDAG)
-    for i in eachindex(dag.nodes)
-        node = dag.nodes[i]
-        for expr in get_exprs(node)
-            node_name = if expr.head == :function
-                if expr.args[1].args[1] isa Expr # function is Module.name instead of just name
-                    expr.args[1].args[1].args[2]
-                else
-                    expr.args[1].args[1]
-                end
-            elseif expr.head == :struct
-                if expr.args[2] isa Expr # struct has type parameter
-                    expr.args[2].args[1]
-                else
-                    expr.args[2]
-                end
-            elseif expr.head == :const
+function node_is_ignored(node)
+    for expr in get_exprs(node)
+        node_name = if expr.head == :function
+            if expr.args[1].args[1] isa Expr # function is Module.name instead of just name
+                expr.args[1].args[1].args[2]
+            else
                 expr.args[1].args[1]
             end
-            # remove the node by renaming it to IGNORED, which we include in the generator's ignorelist
-            if contains(lowercase(string(node_name)), "itt")
-                dag.nodes[i] = ExprNode(:IGNORED, node.type, node.cursor, node.exprs, node.premature_exprs, node.adj)
+        elseif expr.head == :struct
+            if expr.args[2] isa Expr # struct has type parameter
+                expr.args[2].args[1]
+            else
+                expr.args[2]
             end
+        elseif expr.head == :const
+            expr.args[1].args[1]
+        end
+        return contains(lowercase(string(node_name)), "itt")
+    end
+    return false
+end
+
+function remove_itt_symbols!(dag::ExprDAG)
+    for i in eachindex(dag.nodes)
+        # remove the node by renaming it to IGNORED, which we include in the generator's ignorelist
+        node = dag.nodes[i]
+        if node_is_ignored(node)
+            dag.nodes[i] = ExprNode(:IGNORED, node.type, node.cursor, node.exprs, node.premature_exprs, node.adj)
         end
     end
     return nothing
+end
+
+const refs_to_remove = ("AWS_CONTAINER_OF", "AWS_STATIC_STRING_FROM_LITERAL",)
+
+# This is called if the docs generated from the extract_c_comment_style method did not generate any lines.
+# We need to generate at least some docs so that cross-references work with Documenter.jl.
+function get_docs(node, docs)
+    # The macro node types (except for MacroDefault) seem to not generate code, but they will still emit docs and then
+    # you end up with docs stacked on top of each other, which is a Julia LoadError.
+    if node.type isa Generators.AbstractMacroNodeType && !(node.type isa Generators.MacroDefault)
+        return String[]
+    end
+
+    # don't generate empty docs because it makes Documenter.jl mad
+    if isempty(docs)
+        return ["Documentation not found."]
+    end
+
+    # remove references to things which don't exist because it causes Documenter.jl's cross_references check to fail
+    for ref in refs_to_remove
+        for doci in eachindex(docs)
+            docs[doci] = replace(docs[doci], "[`$ref`](@ref)" => "`$ref`")
+        end
+    end
+
+    # fix other random stuff
+    for doci in eachindex(docs)
+        # fix some code that gets bogus references inserted
+        docs[doci] = replace(docs[doci], "for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }" => "`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`")
+    end
+
+    return docs
 end
 
 for target in JLLEnvs.JLL_ENV_TRIPLES
@@ -40,9 +77,11 @@ for target in JLLEnvs.JLL_ENV_TRIPLES
     end
     options = load_options(joinpath(@__DIR__, "generator.toml"))
     options["general"]["output_file_path"] = joinpath(@__DIR__, "..", "lib", "$target.jl")
+    options["general"]["callback_documentation"] = get_docs
 
     header_dirs = []
     args = get_default_args(target)
+    push!(args, "-fparse-all-comments")
     inc = JLLEnvs.get_pkg_include_dir(aws_c_common_jll, target)
     push!(args, "-I$inc")
     push!(header_dirs, inc)

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,57 +1,122 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const __darwin_time_t = Clong
 
+"""
+Documentation not found
+"""
 const __darwin_pid_t = Int32
 
+"""
+Documentation not found
+"""
 const __darwin_uid_t = UInt32
 
+"""
+    __darwin_pthread_handler_rec
+
+Documentation not found
+"""
 struct __darwin_pthread_handler_rec
     __routine::Ptr{Cvoid}
     __arg::Ptr{Cvoid}
     __next::Ptr{__darwin_pthread_handler_rec}
 end
 
+"""
+    _opaque_pthread_cond_t
+
+Documentation not found
+"""
 struct _opaque_pthread_cond_t
     __sig::Clong
     __opaque::NTuple{40, Cchar}
 end
 
+"""
+    _opaque_pthread_mutex_t
+
+Documentation not found
+"""
 struct _opaque_pthread_mutex_t
     __sig::Clong
     __opaque::NTuple{56, Cchar}
 end
 
+"""
+    _opaque_pthread_once_t
+
+Documentation not found
+"""
 struct _opaque_pthread_once_t
     __sig::Clong
     __opaque::NTuple{8, Cchar}
 end
 
+"""
+    _opaque_pthread_rwlock_t
+
+Documentation not found
+"""
 struct _opaque_pthread_rwlock_t
     __sig::Clong
     __opaque::NTuple{192, Cchar}
 end
 
+"""
+    _opaque_pthread_t
+
+Documentation not found
+"""
 struct _opaque_pthread_t
     __sig::Clong
     __cleanup_stack::Ptr{__darwin_pthread_handler_rec}
     __opaque::NTuple{8176, Cchar}
 end
 
+"""
+Documentation not found
+"""
 const __darwin_pthread_cond_t = _opaque_pthread_cond_t
 
+"""
+Documentation not found
+"""
 const __darwin_pthread_mutex_t = _opaque_pthread_mutex_t
 
+"""
+Documentation not found
+"""
 const __darwin_pthread_once_t = _opaque_pthread_once_t
 
+"""
+Documentation not found
+"""
 const __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t
 
+"""
+Documentation not found
+"""
 const __darwin_pthread_t = Ptr{_opaque_pthread_t}
 
+"""
+Documentation not found
+"""
 const pid_t = __darwin_pid_t
 
+"""
+Documentation not found
+"""
 const uid_t = __darwin_uid_t
 
+"""
+    sigval
+
+Documentation not found
+"""
 struct sigval
     data::NTuple{8, UInt8}
 end
@@ -73,6 +138,11 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __siginfo
+
+Documentation not found
+"""
 struct __siginfo
     data::NTuple{104, UInt8}
 end
@@ -102,20 +172,46 @@ function Base.setproperty!(x::Ptr{__siginfo}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const siginfo_t = __siginfo
 
+"""
+Documentation not found
+"""
 const time_t = __darwin_time_t
 
+"""
+Documentation not found
+"""
 const pthread_cond_t = __darwin_pthread_cond_t
 
+"""
+Documentation not found
+"""
 const pthread_mutex_t = __darwin_pthread_mutex_t
 
+"""
+Documentation not found
+"""
 const pthread_once_t = __darwin_pthread_once_t
 
+"""
+Documentation not found
+"""
 const pthread_rwlock_t = __darwin_pthread_rwlock_t
 
+"""
+Documentation not found
+"""
 const pthread_t = __darwin_pthread_t
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -130,6 +226,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -155,6 +256,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -167,6 +269,8 @@ end
 """
     aws_aligned_allocator()
 
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
+
 ### Prototype
 ```c
 struct aws_allocator *aws_aligned_allocator(void);
@@ -176,8 +280,14 @@ function aws_aligned_allocator()
     ccall((:aws_aligned_allocator, libaws_c_common), Ptr{aws_allocator}, ())
 end
 
+"""
+Avoid pulling in CoreFoundation headers in a header file.
+"""
 mutable struct __CFAllocator end
 
+"""
+Documentation not found
+"""
 const CFAllocatorRef = Ptr{__CFAllocator}
 
 """
@@ -266,6 +376,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -274,6 +389,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -287,6 +404,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -298,6 +417,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -311,6 +432,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -322,6 +445,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -335,6 +460,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -346,6 +473,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -359,6 +488,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -370,6 +501,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -383,6 +516,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -395,6 +530,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -406,6 +543,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -559,6 +698,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -571,6 +711,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -583,6 +724,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -595,6 +737,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -621,6 +764,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -633,6 +777,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -645,6 +790,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -657,6 +803,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -837,6 +984,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -849,6 +997,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -861,6 +1010,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -873,6 +1023,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -885,6 +1036,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -897,6 +1049,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -909,6 +1062,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -921,6 +1075,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -933,6 +1088,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -945,6 +1101,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -957,6 +1114,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -969,6 +1127,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -981,6 +1140,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -993,6 +1153,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1005,6 +1166,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1017,6 +1179,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1029,6 +1192,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1041,6 +1205,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1053,6 +1218,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1065,6 +1231,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1077,6 +1244,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1089,6 +1257,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1101,6 +1270,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1113,6 +1283,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1122,10 +1293,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_13
+
+Documentation not found
+"""
 @cenum __JL_Ctag_13::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1513,6 +1694,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1522,6 +1704,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1533,6 +1718,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1954,6 +2146,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2210,6 +2403,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2306,6 +2500,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2932,6 +3127,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2944,6 +3140,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2956,6 +3153,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2968,6 +3166,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2980,6 +3179,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3507,6 +3707,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3526,6 +3731,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3844,6 +4054,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3885,6 +4096,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3911,6 +4127,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3956,6 +4177,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3968,6 +4191,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3980,6 +4204,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -3992,6 +4217,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4004,6 +4230,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4099,6 +4326,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4162,6 +4394,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4184,6 +4421,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4278,6 +4522,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4288,8 +4533,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4351,6 +4604,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4412,6 +4670,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4438,6 +4701,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4470,11 +4736,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_84
+
+Documentation not found
+"""
 @cenum __JL_Ctag_84::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4482,6 +4758,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4497,6 +4778,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4507,6 +4793,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4653,6 +4944,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4665,6 +4957,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4677,6 +4970,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4689,6 +4983,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4701,6 +4996,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4713,6 +5009,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4725,6 +5022,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4737,6 +5035,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4749,6 +5048,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4761,6 +5061,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4773,6 +5074,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4883,6 +5185,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4894,6 +5198,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4907,6 +5213,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4918,6 +5226,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4931,6 +5241,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4942,6 +5254,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4955,6 +5269,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4966,6 +5282,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4979,6 +5297,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4990,6 +5310,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -5003,6 +5325,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5014,6 +5338,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5027,6 +5353,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5038,6 +5366,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5051,6 +5381,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5062,6 +5394,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5075,6 +5409,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5084,6 +5420,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5094,6 +5435,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5107,6 +5450,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5116,6 +5461,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5140,6 +5490,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5164,6 +5517,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5176,6 +5530,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5215,6 +5570,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5223,6 +5583,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5236,6 +5598,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5248,6 +5612,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5257,6 +5623,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5265,16 +5636,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5288,6 +5669,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5299,6 +5682,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5312,6 +5697,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5323,6 +5710,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5336,6 +5725,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5347,6 +5738,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5360,6 +5753,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5372,6 +5767,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5383,6 +5780,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5410,6 +5809,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5447,6 +5847,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5541,14 +5946,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5829,6 +6247,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5841,6 +6267,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5850,6 +6280,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_127
+
+Documentation not found
+"""
 @cenum __JL_Ctag_127::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5868,12 +6303,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6228,6 +6673,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6321,6 +6767,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7185,33 +7634,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7221,6 +7706,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7234,6 +7723,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7246,6 +7739,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7256,22 +7751,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7294,6 +7812,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7308,6 +7831,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7320,6 +7847,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7329,6 +7858,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7336,6 +7870,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7349,6 +7885,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7361,6 +7899,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7372,6 +7912,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7412,6 +7954,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7443,21 +7990,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_194
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_194::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7471,6 +8038,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7586,6 +8160,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7647,6 +8224,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7659,6 +8238,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7670,6 +8251,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7722,12 +8305,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_201
+
+Documentation not found
+"""
 @cenum __JL_Ctag_201::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7803,14 +8400,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8067,12 +8677,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8140,6 +8760,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8152,6 +8773,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8175,10 +8797,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8192,6 +8819,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8203,6 +8832,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8216,6 +8847,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8227,6 +8860,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8240,6 +8875,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8251,6 +8888,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8264,6 +8903,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8275,6 +8916,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8288,6 +8931,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8300,6 +8945,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8310,14 +8957,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8408,6 +9068,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8516,6 +9178,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8565,6 +9232,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8591,6 +9259,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8617,6 +9286,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8626,8 +9296,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_260
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_260::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8665,12 +9343,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8835,6 +9522,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9044,17 +9732,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9076,6 +9777,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9088,6 +9790,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9160,6 +9863,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9171,6 +9876,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9226,6 +9933,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9237,6 +9946,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9250,6 +9961,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9262,6 +9975,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9273,6 +9988,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9300,6 +10017,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9309,6 +10028,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9317,6 +10041,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9327,6 +10053,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9338,6 +10069,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_369
+
+honor the ABI compat
+"""
 struct __JL_Ctag_369
     data::NTuple{8, UInt8}
 end
@@ -9359,6 +10095,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_369}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{64, UInt8}
 end
@@ -9385,6 +10126,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9408,6 +10154,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9449,6 +10197,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9544,6 +10293,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9571,6 +10325,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9578,8 +10337,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9603,6 +10370,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9775,6 +10543,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9851,6 +10622,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10061,6 +10835,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10274,10 +11049,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_332
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_332::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10285,6 +11070,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10297,6 +11083,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10309,6 +11096,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10321,6 +11109,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10330,8 +11119,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10349,6 +11146,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10401,6 +11203,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10413,6 +11217,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10424,6 +11230,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10641,14 +11449,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10661,6 +11483,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10673,6 +11496,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -10685,6 +11509,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10694,38 +11519,86 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10734,18 +11607,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 64
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -10754,15 +11648,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,24 +1,24 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_time_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pid_t = Int32
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_uid_t = UInt32
 
 """
     __darwin_pthread_handler_rec
 
-Documentation not found
+Documentation not found.
 """
 struct __darwin_pthread_handler_rec
     __routine::Ptr{Cvoid}
@@ -29,7 +29,7 @@ end
 """
     _opaque_pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct _opaque_pthread_cond_t
     __sig::Clong
@@ -39,7 +39,7 @@ end
 """
     _opaque_pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct _opaque_pthread_mutex_t
     __sig::Clong
@@ -49,7 +49,7 @@ end
 """
     _opaque_pthread_once_t
 
-Documentation not found
+Documentation not found.
 """
 struct _opaque_pthread_once_t
     __sig::Clong
@@ -59,7 +59,7 @@ end
 """
     _opaque_pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct _opaque_pthread_rwlock_t
     __sig::Clong
@@ -69,7 +69,7 @@ end
 """
     _opaque_pthread_t
 
-Documentation not found
+Documentation not found.
 """
 struct _opaque_pthread_t
     __sig::Clong
@@ -78,44 +78,44 @@ struct _opaque_pthread_t
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pthread_cond_t = _opaque_pthread_cond_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pthread_mutex_t = _opaque_pthread_mutex_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pthread_once_t = _opaque_pthread_once_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pthread_t = Ptr{_opaque_pthread_t}
 
 """
-Documentation not found
+Documentation not found.
 """
 const pid_t = __darwin_pid_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const uid_t = __darwin_uid_t
 
 """
     sigval
 
-Documentation not found
+Documentation not found.
 """
 struct sigval
     data::NTuple{8, UInt8}
@@ -141,7 +141,7 @@ end
 """
     __siginfo
 
-Documentation not found
+Documentation not found.
 """
 struct __siginfo
     data::NTuple{104, UInt8}
@@ -173,44 +173,44 @@ function Base.setproperty!(x::Ptr{__siginfo}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const siginfo_t = __siginfo
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = __darwin_time_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_cond_t = __darwin_pthread_cond_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_mutex_t = __darwin_pthread_mutex_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = __darwin_pthread_once_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_rwlock_t = __darwin_pthread_rwlock_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = __darwin_pthread_t
 
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -256,7 +256,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -286,7 +286,7 @@ Avoid pulling in CoreFoundation headers in a header file.
 mutable struct __CFAllocator end
 
 """
-Documentation not found
+Documentation not found.
 """
 const CFAllocatorRef = Ptr{__CFAllocator}
 
@@ -698,7 +698,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -711,7 +711,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -724,7 +724,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -737,7 +737,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -764,7 +764,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -777,7 +777,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -790,7 +790,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -803,7 +803,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -984,7 +984,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -997,7 +997,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -1010,7 +1010,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -1023,7 +1023,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -1036,7 +1036,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -1049,7 +1049,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -1062,7 +1062,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1075,7 +1075,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1088,7 +1088,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1101,7 +1101,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1114,7 +1114,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1127,7 +1127,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1140,7 +1140,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1153,7 +1153,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1166,7 +1166,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1179,7 +1179,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1192,7 +1192,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1205,7 +1205,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1218,7 +1218,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1231,7 +1231,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1244,7 +1244,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1257,7 +1257,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1270,7 +1270,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1283,7 +1283,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1296,7 +1296,7 @@ end
 """
     __JL_Ctag_13
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_13::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1305,7 +1305,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1694,7 +1694,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1705,7 +1705,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2146,7 +2146,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2403,7 +2403,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2500,7 +2500,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3127,7 +3127,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3140,7 +3140,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3153,7 +3153,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3166,7 +3166,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3179,7 +3179,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3710,7 +3710,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3734,7 +3734,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -4054,7 +4054,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4099,7 +4099,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4130,7 +4130,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4191,7 +4191,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4204,7 +4204,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4217,7 +4217,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4230,7 +4230,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4329,7 +4329,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4397,7 +4397,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4474,13 +4474,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4522,7 +4522,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4534,14 +4534,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4607,7 +4607,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4673,7 +4673,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4702,7 +4702,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4739,7 +4739,7 @@ end
 """
     __JL_Ctag_84
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_84::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4749,7 +4749,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4761,7 +4761,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4781,7 +4781,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4796,7 +4796,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4944,7 +4944,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4957,7 +4957,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4970,7 +4970,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4983,7 +4983,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4996,7 +4996,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -5009,7 +5009,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -5022,7 +5022,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -5035,7 +5035,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -5048,7 +5048,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -5061,7 +5061,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5074,7 +5074,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5423,7 +5423,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5464,7 +5464,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5476,10 +5476,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5491,7 +5491,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5502,7 +5502,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5517,7 +5517,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5530,7 +5530,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5573,7 +5573,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5626,7 +5626,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5639,7 +5639,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5648,7 +5648,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5809,7 +5809,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5850,7 +5850,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5947,14 +5947,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5965,7 +5965,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6205,7 +6205,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6283,7 +6283,7 @@ end
 """
     __JL_Ctag_127
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_127::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6306,7 +6306,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6317,7 +6317,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6443,7 +6443,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6461,7 +6461,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6673,7 +6673,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6768,7 +6768,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6779,10 +6779,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6800,10 +6800,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6821,9 +6821,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6841,10 +6841,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6862,9 +6862,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6882,9 +6882,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6900,10 +6900,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6919,10 +6919,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6938,10 +6938,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6959,11 +6959,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6979,10 +6979,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6998,10 +6998,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -7017,10 +7017,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -7042,11 +7042,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -7064,10 +7064,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7083,10 +7083,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7102,9 +7102,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7120,10 +7120,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7145,11 +7145,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7165,11 +7165,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7185,9 +7185,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7203,9 +7203,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7221,9 +7221,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7239,9 +7239,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7257,9 +7257,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7275,9 +7275,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7293,9 +7293,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7313,7 +7313,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7333,10 +7333,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7356,10 +7356,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7375,10 +7375,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7552,7 +7552,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7635,20 +7635,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7657,20 +7657,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7752,20 +7752,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7788,7 +7788,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7815,7 +7815,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7861,7 +7861,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7957,7 +7957,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -8002,7 +8002,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -8013,7 +8013,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -8023,7 +8023,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8083,10 +8083,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8116,10 +8116,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8161,7 +8161,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8306,24 +8306,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_201
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_201::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8408,7 +8408,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8419,7 +8419,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8648,7 +8648,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8664,9 +8664,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8680,7 +8680,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8691,7 +8691,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8702,7 +8702,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8760,7 +8760,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8773,7 +8773,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8958,7 +8958,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8976,7 +8976,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8988,7 +8988,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -9006,9 +9006,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -9024,9 +9024,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9181,7 +9181,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9232,7 +9232,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9259,7 +9259,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9286,7 +9286,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9297,7 +9297,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9431,7 +9431,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9522,7 +9524,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9633,7 +9635,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9735,7 +9737,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9746,7 +9748,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9754,7 +9756,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9777,7 +9779,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9790,7 +9792,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -10031,7 +10033,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -10056,7 +10058,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10129,7 +10131,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10197,7 +10199,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10296,7 +10298,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10328,7 +10330,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10338,14 +10340,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10370,7 +10372,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10544,7 +10546,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10623,7 +10625,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10835,7 +10837,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -11052,7 +11054,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11070,7 +11072,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11083,7 +11085,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11096,7 +11098,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11109,7 +11111,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11120,14 +11122,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11149,7 +11151,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11450,26 +11452,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11483,7 +11485,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11496,7 +11498,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -11509,7 +11511,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11520,84 +11522,84 @@ function enable_vt_mode()
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11608,37 +11610,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 64
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11649,32 +11651,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,24 +1,55 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const __uid_t = Cuint
 
+"""
+Documentation not found
+"""
 const __pid_t = Cint
 
+"""
+Documentation not found
+"""
 const __clock_t = Clong
 
+"""
+Documentation not found
+"""
 const __time_t = Clong
 
+"""
+Documentation not found
+"""
 const time_t = __time_t
 
+"""
+Documentation not found
+"""
 const pthread_t = Culong
 
+"""
+    __pthread_internal_list
+
+Documentation not found
+"""
 struct __pthread_internal_list
     __prev::Ptr{__pthread_internal_list}
     __next::Ptr{__pthread_internal_list}
 end
 
+"""
+Documentation not found
+"""
 const __pthread_list_t = __pthread_internal_list
 
+"""
+    pthread_mutex_t
+
+Documentation not found
+"""
 struct pthread_mutex_t
     data::NTuple{48, UInt8}
 end
@@ -41,6 +72,11 @@ function Base.setproperty!(x::Ptr{pthread_mutex_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_cond_t
+
+Documentation not found
+"""
 struct pthread_cond_t
     data::NTuple{48, UInt8}
 end
@@ -63,8 +99,16 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const pthread_once_t = Cint
 
+"""
+    pthread_rwlock_t
+
+Documentation not found
+"""
 struct pthread_rwlock_t
     data::NTuple{56, UInt8}
 end
@@ -87,6 +131,11 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -101,6 +150,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    sigval
+
+Documentation not found
+"""
 struct sigval
     data::NTuple{8, UInt8}
 end
@@ -122,8 +176,16 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const sigval_t = sigval
 
+"""
+    __JL_Ctag_1214
+
+Documentation not found
+"""
 struct __JL_Ctag_1214
     data::NTuple{112, UInt8}
 end
@@ -151,6 +213,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1214}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    siginfo_t
+
+Documentation not found
+"""
 struct siginfo_t
     data::NTuple{128, UInt8}
 end
@@ -174,6 +241,11 @@ function Base.setproperty!(x::Ptr{siginfo_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -199,6 +271,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -210,6 +283,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -278,6 +353,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -286,6 +366,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -299,6 +381,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -310,6 +394,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -323,6 +409,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -334,6 +422,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -347,6 +437,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -358,6 +450,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -371,6 +465,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -382,6 +478,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -395,6 +493,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -407,6 +507,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -418,6 +520,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -571,6 +675,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -583,6 +688,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -595,6 +701,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -607,6 +714,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -633,6 +741,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -645,6 +754,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -657,6 +767,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -669,6 +780,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -849,6 +961,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -861,6 +974,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -873,6 +987,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -885,6 +1000,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -897,6 +1013,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -909,6 +1026,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -921,6 +1039,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -933,6 +1052,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -945,6 +1065,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -957,6 +1078,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -969,6 +1091,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -981,6 +1104,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -993,6 +1117,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1005,6 +1130,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1017,6 +1143,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1029,6 +1156,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1041,6 +1169,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1053,6 +1182,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1065,6 +1195,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1077,6 +1208,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1089,6 +1221,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1101,6 +1234,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1113,6 +1247,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1125,6 +1260,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1134,10 +1270,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_39
+
+Documentation not found
+"""
 @cenum __JL_Ctag_39::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1525,6 +1671,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1534,6 +1681,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1545,6 +1695,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1966,6 +2123,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2222,6 +2380,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2318,6 +2477,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2944,6 +3104,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2956,6 +3117,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2968,6 +3130,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2980,6 +3143,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2992,6 +3156,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3519,6 +3684,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3538,6 +3708,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3856,6 +4031,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3897,6 +4073,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3923,6 +4104,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3968,6 +4154,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3980,6 +4168,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3992,6 +4181,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4004,6 +4194,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4016,6 +4207,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4111,6 +4303,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4174,6 +4371,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4196,6 +4398,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4290,6 +4499,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4300,8 +4510,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4363,6 +4581,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4424,6 +4647,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4450,6 +4678,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4482,11 +4713,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_283
+
+Documentation not found
+"""
 @cenum __JL_Ctag_283::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4494,6 +4735,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4509,6 +4755,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4519,6 +4770,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4665,6 +4921,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4677,6 +4934,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4689,6 +4947,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4701,6 +4960,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4713,6 +4973,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4725,6 +4986,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4737,6 +4999,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4749,6 +5012,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4761,6 +5025,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4773,6 +5038,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4785,6 +5051,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4895,6 +5162,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4906,6 +5175,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4919,6 +5190,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4930,6 +5203,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4943,6 +5218,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4954,6 +5231,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4967,6 +5246,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4978,6 +5259,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4991,6 +5274,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -5002,6 +5287,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -5015,6 +5302,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5026,6 +5315,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5039,6 +5330,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5050,6 +5343,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5063,6 +5358,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5074,6 +5371,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5087,6 +5386,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5096,6 +5397,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5106,6 +5412,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5119,6 +5427,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5128,6 +5438,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5152,6 +5467,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5176,6 +5494,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5188,6 +5507,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5227,6 +5547,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5235,6 +5560,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5248,6 +5575,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5260,6 +5589,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5269,6 +5600,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5277,16 +5613,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5300,6 +5646,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5311,6 +5659,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5324,6 +5674,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5335,6 +5687,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5348,6 +5702,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5359,6 +5715,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5372,6 +5730,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5384,6 +5744,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5395,6 +5757,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5422,6 +5786,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5459,6 +5824,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5553,14 +5923,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5841,6 +6224,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5853,6 +6244,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5862,6 +6257,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_429
+
+Documentation not found
+"""
 @cenum __JL_Ctag_429::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5880,12 +6280,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6240,6 +6650,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6333,6 +6744,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7197,33 +7611,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7233,6 +7683,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7246,6 +7700,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7258,6 +7716,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7268,22 +7728,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7306,6 +7789,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7320,6 +7808,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7332,6 +7824,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7341,6 +7835,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7348,6 +7847,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7361,6 +7862,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7373,6 +7876,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7384,6 +7889,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7424,6 +7931,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7455,21 +7967,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_645
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_645::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7483,6 +8015,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7598,6 +8137,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7659,6 +8201,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7671,6 +8215,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7682,6 +8228,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7734,12 +8282,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_665
+
+Documentation not found
+"""
 @cenum __JL_Ctag_665::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7815,14 +8377,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8079,12 +8654,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8152,6 +8737,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8164,6 +8750,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8187,10 +8774,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8204,6 +8796,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8215,6 +8809,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8228,6 +8824,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8239,6 +8837,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8252,6 +8852,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8263,6 +8865,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8276,6 +8880,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8287,6 +8893,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8300,6 +8908,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8312,6 +8922,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8322,14 +8934,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8420,6 +9045,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8528,6 +9155,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8577,6 +9209,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8603,6 +9236,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8629,6 +9263,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8638,8 +9273,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_861
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_861::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8677,12 +9320,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8847,6 +9499,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9056,17 +9709,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9088,6 +9754,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9100,6 +9767,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9172,6 +9840,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9183,6 +9853,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9238,6 +9910,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9249,6 +9923,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9262,6 +9938,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9274,6 +9952,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9285,6 +9965,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9312,6 +9994,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9321,6 +10005,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9329,6 +10018,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9339,6 +10030,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9350,6 +10046,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_1250
+
+honor the ABI compat
+"""
 struct __JL_Ctag_1250
     data::NTuple{8, UInt8}
 end
@@ -9371,6 +10072,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1250}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{64, UInt8}
 end
@@ -9397,6 +10103,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9420,6 +10131,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9461,6 +10174,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9556,6 +10270,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9583,6 +10302,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9590,8 +10314,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9615,6 +10347,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9787,6 +10520,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9863,6 +10599,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10073,6 +10812,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10286,10 +11026,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_1090
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_1090::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10297,6 +11047,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10309,6 +11060,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10321,6 +11073,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10333,6 +11086,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10342,8 +11096,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10361,6 +11123,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10413,6 +11180,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10425,6 +11194,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10436,6 +11207,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10653,14 +11426,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10673,6 +11460,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10685,6 +11473,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -10697,6 +11486,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10706,6 +11496,11 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+    __JL_Ctag_1197
+
+Documentation not found
+"""
 struct __JL_Ctag_1197
     __lock::Cint
     __futex::Cuint
@@ -10740,6 +11535,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1197}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1198
+
+Documentation not found
+"""
 struct __JL_Ctag_1198
     __lock::Cint
     __nr_readers::Cuint
@@ -10780,6 +11580,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1198}, f::Symbol, v)
 end
 
 
+"""
+    __pthread_mutex_s
+
+Documentation not found
+"""
 struct __pthread_mutex_s
     __lock::Cint
     __count::Cuint
@@ -10790,6 +11595,11 @@ struct __pthread_mutex_s
     __list::__pthread_list_t
 end
 
+"""
+    __JL_Ctag_1215
+
+Documentation not found
+"""
 struct __JL_Ctag_1215
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10812,6 +11622,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1215}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1216
+
+Documentation not found
+"""
 struct __JL_Ctag_1216
     si_tid::Cint
     si_overrun::Cint
@@ -10836,6 +11651,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1216}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1217
+
+Documentation not found
+"""
 struct __JL_Ctag_1217
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10860,6 +11680,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1217}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1218
+
+Documentation not found
+"""
 struct __JL_Ctag_1218
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10888,6 +11713,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1218}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1219
+
+Documentation not found
+"""
 struct __JL_Ctag_1219
     si_addr::Ptr{Cvoid}
     si_addr_lsb::Cshort
@@ -10910,6 +11740,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1219}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1220
+
+Documentation not found
+"""
 struct __JL_Ctag_1220
     si_band::Clong
     si_fd::Cint
@@ -10932,6 +11767,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1220}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1221
+
+Documentation not found
+"""
 struct __JL_Ctag_1221
     _call_addr::Ptr{Cvoid}
     _syscall::Cint
@@ -10956,38 +11796,86 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1221}, f::Symbol, v)
 end
 
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10996,18 +11884,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 64
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -11016,15 +11925,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,39 +1,39 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const __uid_t = Cuint
 
 """
-Documentation not found
+Documentation not found.
 """
 const __pid_t = Cint
 
 """
-Documentation not found
+Documentation not found.
 """
 const __clock_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const __time_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = __time_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = Culong
 
 """
     __pthread_internal_list
 
-Documentation not found
+Documentation not found.
 """
 struct __pthread_internal_list
     __prev::Ptr{__pthread_internal_list}
@@ -41,14 +41,14 @@ struct __pthread_internal_list
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const __pthread_list_t = __pthread_internal_list
 
 """
     pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_mutex_t
     data::NTuple{48, UInt8}
@@ -75,7 +75,7 @@ end
 """
     pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_cond_t
     data::NTuple{48, UInt8}
@@ -100,14 +100,14 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = Cint
 
 """
     pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_rwlock_t
     data::NTuple{56, UInt8}
@@ -134,7 +134,7 @@ end
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -153,7 +153,7 @@ end
 """
     sigval
 
-Documentation not found
+Documentation not found.
 """
 struct sigval
     data::NTuple{8, UInt8}
@@ -177,14 +177,14 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const sigval_t = sigval
 
 """
     __JL_Ctag_1214
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1214
     data::NTuple{112, UInt8}
@@ -216,7 +216,7 @@ end
 """
     siginfo_t
 
-Documentation not found
+Documentation not found.
 """
 struct siginfo_t
     data::NTuple{128, UInt8}
@@ -271,7 +271,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -675,7 +675,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -688,7 +688,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -701,7 +701,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -714,7 +714,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -741,7 +741,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -754,7 +754,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -767,7 +767,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -780,7 +780,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -961,7 +961,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -974,7 +974,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -987,7 +987,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -1000,7 +1000,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -1013,7 +1013,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -1026,7 +1026,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -1039,7 +1039,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1052,7 +1052,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1065,7 +1065,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1078,7 +1078,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1091,7 +1091,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1104,7 +1104,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1117,7 +1117,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1130,7 +1130,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1143,7 +1143,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1156,7 +1156,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1169,7 +1169,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1182,7 +1182,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1195,7 +1195,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1208,7 +1208,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1221,7 +1221,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1234,7 +1234,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1247,7 +1247,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1260,7 +1260,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1273,7 +1273,7 @@ end
 """
     __JL_Ctag_39
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_39::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1282,7 +1282,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1671,7 +1671,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1682,7 +1682,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2123,7 +2123,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2380,7 +2380,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2477,7 +2477,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3104,7 +3104,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3117,7 +3117,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3130,7 +3130,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3143,7 +3143,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3156,7 +3156,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3687,7 +3687,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3711,7 +3711,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -4031,7 +4031,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4076,7 +4076,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4107,7 +4107,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4168,7 +4168,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4181,7 +4181,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4194,7 +4194,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4207,7 +4207,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4306,7 +4306,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4374,7 +4374,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4451,13 +4451,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4499,7 +4499,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4511,14 +4511,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4584,7 +4584,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4650,7 +4650,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4679,7 +4679,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4716,7 +4716,7 @@ end
 """
     __JL_Ctag_283
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_283::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4726,7 +4726,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4738,7 +4738,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4758,7 +4758,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4773,7 +4773,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4921,7 +4921,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4934,7 +4934,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4947,7 +4947,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4960,7 +4960,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4973,7 +4973,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4986,7 +4986,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4999,7 +4999,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -5012,7 +5012,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -5025,7 +5025,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -5038,7 +5038,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5051,7 +5051,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5400,7 +5400,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5441,7 +5441,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5453,10 +5453,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5468,7 +5468,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5479,7 +5479,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5494,7 +5494,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5507,7 +5507,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5550,7 +5550,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5603,7 +5603,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5616,7 +5616,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5625,7 +5625,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5786,7 +5786,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5827,7 +5827,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5924,14 +5924,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5942,7 +5942,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6182,7 +6182,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6260,7 +6260,7 @@ end
 """
     __JL_Ctag_429
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_429::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6283,7 +6283,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6294,7 +6294,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6420,7 +6420,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6438,7 +6438,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6650,7 +6650,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6745,7 +6745,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6756,10 +6756,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6777,10 +6777,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6798,9 +6798,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6818,10 +6818,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6839,9 +6839,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6859,9 +6859,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6877,10 +6877,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6896,10 +6896,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6915,10 +6915,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6936,11 +6936,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6956,10 +6956,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6975,10 +6975,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6994,10 +6994,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -7019,11 +7019,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -7041,10 +7041,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7060,10 +7060,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7079,9 +7079,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7097,10 +7097,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7122,11 +7122,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7142,11 +7142,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7162,9 +7162,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7180,9 +7180,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7198,9 +7198,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7216,9 +7216,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7234,9 +7234,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7252,9 +7252,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7270,9 +7270,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7290,7 +7290,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7310,10 +7310,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7333,10 +7333,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7352,10 +7352,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7529,7 +7529,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7612,20 +7612,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7634,20 +7634,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7729,20 +7729,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7765,7 +7765,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7792,7 +7792,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7838,7 +7838,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7934,7 +7934,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7979,7 +7979,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7990,7 +7990,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -8000,7 +8000,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8060,10 +8060,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8093,10 +8093,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8138,7 +8138,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8283,24 +8283,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_665
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_665::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8385,7 +8385,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8396,7 +8396,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8625,7 +8625,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8641,9 +8641,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8657,7 +8657,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8668,7 +8668,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8679,7 +8679,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8737,7 +8737,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8750,7 +8750,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8935,7 +8935,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8953,7 +8953,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8965,7 +8965,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8983,9 +8983,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -9001,9 +9001,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9158,7 +9158,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9209,7 +9209,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9236,7 +9236,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9263,7 +9263,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9274,7 +9274,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9408,7 +9408,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9499,7 +9501,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9610,7 +9612,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9712,7 +9714,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9723,7 +9725,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9731,7 +9733,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9754,7 +9756,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9767,7 +9769,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -10008,7 +10010,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -10033,7 +10035,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10106,7 +10108,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10174,7 +10176,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10273,7 +10275,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10305,7 +10307,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10315,14 +10317,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10347,7 +10349,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10521,7 +10523,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10600,7 +10602,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10812,7 +10814,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -11029,7 +11031,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11047,7 +11049,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11060,7 +11062,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11073,7 +11075,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11086,7 +11088,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11097,14 +11099,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11126,7 +11128,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11427,26 +11429,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11460,7 +11462,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11473,7 +11475,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -11486,7 +11488,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11499,7 +11501,7 @@ end
 """
     __JL_Ctag_1197
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1197
     __lock::Cint
@@ -11538,7 +11540,7 @@ end
 """
     __JL_Ctag_1198
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1198
     __lock::Cint
@@ -11583,7 +11585,7 @@ end
 """
     __pthread_mutex_s
 
-Documentation not found
+Documentation not found.
 """
 struct __pthread_mutex_s
     __lock::Cint
@@ -11598,7 +11600,7 @@ end
 """
     __JL_Ctag_1215
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1215
     si_pid::__pid_t
@@ -11625,7 +11627,7 @@ end
 """
     __JL_Ctag_1216
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1216
     si_tid::Cint
@@ -11654,7 +11656,7 @@ end
 """
     __JL_Ctag_1217
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1217
     si_pid::__pid_t
@@ -11683,7 +11685,7 @@ end
 """
     __JL_Ctag_1218
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1218
     si_pid::__pid_t
@@ -11716,7 +11718,7 @@ end
 """
     __JL_Ctag_1219
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1219
     si_addr::Ptr{Cvoid}
@@ -11743,7 +11745,7 @@ end
 """
     __JL_Ctag_1220
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1220
     si_band::Clong
@@ -11770,7 +11772,7 @@ end
 """
     __JL_Ctag_1221
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1221
     _call_addr::Ptr{Cvoid}
@@ -11797,84 +11799,84 @@ end
 
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11885,37 +11887,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 64
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11926,32 +11928,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,7 +1,15 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const time_t = Clong
 
+"""
+    __JL_Ctag_328
+
+Documentation not found
+"""
 struct __JL_Ctag_328
     data::NTuple{40, UInt8}
 end
@@ -24,6 +32,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_328}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_mutex_t
+
+Documentation not found
+"""
 struct pthread_mutex_t
     data::NTuple{40, UInt8}
 end
@@ -44,6 +57,11 @@ function Base.setproperty!(x::Ptr{pthread_mutex_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __JL_Ctag_324
+
+Documentation not found
+"""
 struct __JL_Ctag_324
     data::NTuple{48, UInt8}
 end
@@ -66,6 +84,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_324}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_cond_t
+
+Documentation not found
+"""
 struct pthread_cond_t
     data::NTuple{48, UInt8}
 end
@@ -86,6 +109,11 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __JL_Ctag_331
+
+Documentation not found
+"""
 struct __JL_Ctag_331
     data::NTuple{56, UInt8}
 end
@@ -108,6 +136,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_331}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_rwlock_t
+
+Documentation not found
+"""
 struct pthread_rwlock_t
     data::NTuple{56, UInt8}
 end
@@ -128,12 +161,26 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 mutable struct __pthread end
 
+"""
+Documentation not found
+"""
 const pthread_t = Ptr{__pthread}
 
+"""
+Documentation not found
+"""
 const pthread_once_t = Cint
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -148,6 +195,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -173,6 +225,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -184,6 +237,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -252,6 +307,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -260,6 +320,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -273,6 +335,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -284,6 +348,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -297,6 +363,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -308,6 +376,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -321,6 +391,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -332,6 +404,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -345,6 +419,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -356,6 +432,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -369,6 +447,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -381,6 +461,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -392,6 +474,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -545,6 +629,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -557,6 +642,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -569,6 +655,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -581,6 +668,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -607,6 +695,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -619,6 +708,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -631,6 +721,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -643,6 +734,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -823,6 +915,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -835,6 +928,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -847,6 +941,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -859,6 +954,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -871,6 +967,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -883,6 +980,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -895,6 +993,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -907,6 +1006,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -919,6 +1019,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -931,6 +1032,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -943,6 +1045,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -955,6 +1058,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -967,6 +1071,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -979,6 +1084,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -991,6 +1097,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1003,6 +1110,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1015,6 +1123,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1027,6 +1136,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1039,6 +1149,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1051,6 +1162,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1063,6 +1175,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1075,6 +1188,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1087,6 +1201,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1099,6 +1214,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1108,10 +1224,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_9
+
+Documentation not found
+"""
 @cenum __JL_Ctag_9::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1499,6 +1625,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1508,6 +1635,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1519,6 +1649,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1940,6 +2077,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2196,6 +2334,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2292,6 +2431,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2918,6 +3058,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2930,6 +3071,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2942,6 +3084,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2954,6 +3097,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2966,6 +3110,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3493,6 +3638,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3512,6 +3662,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3830,6 +3985,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3871,6 +4027,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3897,6 +4058,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3942,6 +4108,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3954,6 +4122,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3966,6 +4135,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -3978,6 +4148,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -3990,6 +4161,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4085,6 +4257,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4148,6 +4325,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4170,6 +4352,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4264,6 +4453,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4274,8 +4464,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4337,6 +4535,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4398,6 +4601,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4424,6 +4632,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4456,11 +4667,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_66
+
+Documentation not found
+"""
 @cenum __JL_Ctag_66::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4468,6 +4689,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4483,6 +4709,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4493,6 +4724,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4639,6 +4875,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4651,6 +4888,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4663,6 +4901,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4675,6 +4914,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4687,6 +4927,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4699,6 +4940,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4711,6 +4953,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4723,6 +4966,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4735,6 +4979,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4747,6 +4992,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4759,6 +5005,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4869,6 +5116,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4880,6 +5129,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4893,6 +5144,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4904,6 +5157,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4917,6 +5172,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4928,6 +5185,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4941,6 +5200,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4952,6 +5213,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4965,6 +5228,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4976,6 +5241,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -4989,6 +5256,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5000,6 +5269,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5013,6 +5284,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5024,6 +5297,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5037,6 +5312,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5048,6 +5325,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5061,6 +5340,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5070,6 +5351,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5080,6 +5366,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5093,6 +5381,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5102,6 +5392,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5126,6 +5421,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5150,6 +5448,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5162,6 +5461,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5201,6 +5501,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5209,6 +5514,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5222,6 +5529,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5234,6 +5543,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5243,6 +5554,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5251,16 +5567,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5274,6 +5600,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5285,6 +5613,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5298,6 +5628,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5309,6 +5641,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5322,6 +5656,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5333,6 +5669,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5346,6 +5684,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5358,6 +5698,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5369,6 +5711,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5396,6 +5740,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5433,6 +5778,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5527,14 +5877,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5815,6 +6178,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5827,6 +6198,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5836,6 +6211,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_97
+
+Documentation not found
+"""
 @cenum __JL_Ctag_97::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5854,12 +6234,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6214,6 +6604,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6307,6 +6698,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7171,33 +7565,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7207,6 +7637,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7220,6 +7654,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7232,6 +7670,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7242,22 +7682,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7280,6 +7743,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7294,6 +7762,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7306,6 +7778,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7315,6 +7789,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7322,6 +7801,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7335,6 +7816,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7347,6 +7830,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7358,6 +7843,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7398,6 +7885,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7429,21 +7921,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_161
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_161::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7457,6 +7969,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7572,6 +8091,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7633,6 +8155,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7645,6 +8169,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7656,6 +8182,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7708,12 +8236,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_166
+
+Documentation not found
+"""
 @cenum __JL_Ctag_166::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7789,14 +8331,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8053,12 +8608,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8126,6 +8691,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8138,6 +8704,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8161,10 +8728,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8178,6 +8750,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8189,6 +8763,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8202,6 +8778,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8213,6 +8791,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8226,6 +8806,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8237,6 +8819,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8250,6 +8834,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8261,6 +8847,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8274,6 +8862,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8286,6 +8876,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8296,14 +8888,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8394,6 +8999,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8502,6 +9109,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8551,6 +9163,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8577,6 +9190,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8603,6 +9217,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8612,8 +9227,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_221
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_221::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8651,12 +9274,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8821,6 +9453,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9030,17 +9663,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9062,6 +9708,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9074,6 +9721,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9146,6 +9794,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9157,6 +9807,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9212,6 +9864,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9223,6 +9877,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9236,6 +9892,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9248,6 +9906,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9259,6 +9919,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9286,6 +9948,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9295,6 +9959,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9303,6 +9972,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9313,6 +9984,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9324,6 +10000,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_320
+
+honor the ABI compat
+"""
 struct __JL_Ctag_320
     data::NTuple{8, UInt8}
 end
@@ -9345,6 +10026,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_320}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{64, UInt8}
 end
@@ -9371,6 +10057,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9394,6 +10085,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9435,6 +10128,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9530,6 +10224,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9557,6 +10256,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9564,8 +10268,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9589,6 +10301,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9761,6 +10474,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9837,6 +10553,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10047,6 +10766,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10260,10 +10980,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_275
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_275::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10271,6 +11001,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10283,6 +11014,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10295,6 +11027,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10307,6 +11040,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10316,8 +11050,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10335,6 +11077,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10387,6 +11134,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10399,6 +11148,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10410,6 +11161,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10627,14 +11380,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10647,6 +11414,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10659,6 +11427,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10668,38 +11437,86 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10708,18 +11525,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 64
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -10728,15 +11566,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,14 +1,14 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = Clong
 
 """
     __JL_Ctag_328
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_328
     data::NTuple{40, UInt8}
@@ -35,7 +35,7 @@ end
 """
     pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_mutex_t
     data::NTuple{40, UInt8}
@@ -60,7 +60,7 @@ end
 """
     __JL_Ctag_324
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_324
     data::NTuple{48, UInt8}
@@ -87,7 +87,7 @@ end
 """
     pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_cond_t
     data::NTuple{48, UInt8}
@@ -112,7 +112,7 @@ end
 """
     __JL_Ctag_331
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_331
     data::NTuple{56, UInt8}
@@ -139,7 +139,7 @@ end
 """
     pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_rwlock_t
     data::NTuple{56, UInt8}
@@ -162,24 +162,24 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct __pthread end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = Ptr{__pthread}
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = Cint
 
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -225,7 +225,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -629,7 +629,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -642,7 +642,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -655,7 +655,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -668,7 +668,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -695,7 +695,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -708,7 +708,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -721,7 +721,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -734,7 +734,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -915,7 +915,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -928,7 +928,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -941,7 +941,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -954,7 +954,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -967,7 +967,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -980,7 +980,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -993,7 +993,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1006,7 +1006,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1019,7 +1019,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1032,7 +1032,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1045,7 +1045,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1058,7 +1058,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1071,7 +1071,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1084,7 +1084,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1097,7 +1097,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1110,7 +1110,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1123,7 +1123,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1136,7 +1136,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1149,7 +1149,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1162,7 +1162,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1175,7 +1175,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1188,7 +1188,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1201,7 +1201,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1214,7 +1214,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1227,7 +1227,7 @@ end
 """
     __JL_Ctag_9
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_9::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1236,7 +1236,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1625,7 +1625,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1636,7 +1636,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2077,7 +2077,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2334,7 +2334,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2431,7 +2431,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3058,7 +3058,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3071,7 +3071,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3084,7 +3084,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3097,7 +3097,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3110,7 +3110,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3641,7 +3641,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3665,7 +3665,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -3985,7 +3985,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4030,7 +4030,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4061,7 +4061,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4122,7 +4122,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4135,7 +4135,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4148,7 +4148,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4161,7 +4161,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4260,7 +4260,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4328,7 +4328,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4405,13 +4405,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4453,7 +4453,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4465,14 +4465,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4538,7 +4538,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4604,7 +4604,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4633,7 +4633,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4670,7 +4670,7 @@ end
 """
     __JL_Ctag_66
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_66::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4680,7 +4680,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4692,7 +4692,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4712,7 +4712,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4727,7 +4727,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4875,7 +4875,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4888,7 +4888,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4901,7 +4901,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4914,7 +4914,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4927,7 +4927,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4940,7 +4940,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4953,7 +4953,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4966,7 +4966,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4979,7 +4979,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4992,7 +4992,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5005,7 +5005,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5354,7 +5354,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5395,7 +5395,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5407,10 +5407,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5422,7 +5422,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5433,7 +5433,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5448,7 +5448,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5461,7 +5461,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5504,7 +5504,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5557,7 +5557,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5570,7 +5570,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5579,7 +5579,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5740,7 +5740,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5781,7 +5781,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5878,14 +5878,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5896,7 +5896,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6136,7 +6136,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6214,7 +6214,7 @@ end
 """
     __JL_Ctag_97
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_97::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6237,7 +6237,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6248,7 +6248,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6374,7 +6374,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6392,7 +6392,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6604,7 +6604,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6699,7 +6699,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6710,10 +6710,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6731,10 +6731,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6752,9 +6752,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6772,10 +6772,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6793,9 +6793,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6813,9 +6813,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6831,10 +6831,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6850,10 +6850,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6869,10 +6869,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6890,11 +6890,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6910,10 +6910,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6929,10 +6929,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6948,10 +6948,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -6973,11 +6973,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -6995,10 +6995,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7014,10 +7014,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7033,9 +7033,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7051,10 +7051,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7076,11 +7076,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7096,11 +7096,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7116,9 +7116,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7134,9 +7134,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7152,9 +7152,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7170,9 +7170,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7188,9 +7188,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7206,9 +7206,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7224,9 +7224,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7244,7 +7244,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7264,10 +7264,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7287,10 +7287,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7306,10 +7306,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7483,7 +7483,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7566,20 +7566,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7588,20 +7588,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7683,20 +7683,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7719,7 +7719,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7746,7 +7746,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7792,7 +7792,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7888,7 +7888,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7933,7 +7933,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7944,7 +7944,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -7954,7 +7954,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8014,10 +8014,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8047,10 +8047,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8092,7 +8092,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8237,24 +8237,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_166
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_166::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8339,7 +8339,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8350,7 +8350,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8579,7 +8579,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8595,9 +8595,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8611,7 +8611,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8622,7 +8622,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8633,7 +8633,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8691,7 +8691,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8704,7 +8704,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8889,7 +8889,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8907,7 +8907,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8919,7 +8919,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8937,9 +8937,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -8955,9 +8955,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9112,7 +9112,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9163,7 +9163,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9190,7 +9190,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9217,7 +9217,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9228,7 +9228,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9362,7 +9362,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9453,7 +9455,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9564,7 +9566,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9666,7 +9668,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9677,7 +9679,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9685,7 +9687,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9708,7 +9710,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9721,7 +9723,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9962,7 +9964,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -9987,7 +9989,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10060,7 +10062,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10128,7 +10130,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10227,7 +10229,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10259,7 +10261,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10269,14 +10271,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10301,7 +10303,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10475,7 +10477,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10554,7 +10556,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10766,7 +10768,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10983,7 +10985,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11001,7 +11003,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11014,7 +11016,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11027,7 +11029,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11040,7 +11042,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11051,14 +11053,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11080,7 +11082,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11381,26 +11383,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11414,7 +11416,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11427,7 +11429,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11438,84 +11440,84 @@ function enable_vt_mode()
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11526,37 +11528,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 64
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11567,32 +11569,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -3,21 +3,6 @@ using CEnum
 """
 Documentation not found.
 """
-const __uid_t = Cuint
-
-"""
-Documentation not found.
-"""
-const __pid_t = Cint
-
-"""
-Documentation not found.
-"""
-const __clock_t = Clong
-
-"""
-Documentation not found.
-"""
 const __time_t = Clong
 
 """
@@ -50,12 +35,12 @@ const __pthread_slist_t = __pthread_internal_slist
 Documentation not found.
 """
 struct pthread_mutex_t
-    data::NTuple{24, UInt8}
+    data::NTuple{24,UInt8}
 end
 
 function Base.getproperty(x::Ptr{pthread_mutex_t}, f::Symbol)
     f === :__data && return Ptr{__pthread_mutex_s}(x + 0)
-    f === :__size && return Ptr{NTuple{24, Cchar}}(x + 0)
+    f === :__size && return Ptr{NTuple{24,Cchar}}(x + 0)
     f === :__align && return Ptr{Clong}(x + 0)
     return getfield(x, f)
 end
@@ -77,12 +62,12 @@ end
 Documentation not found.
 """
 struct pthread_cond_t
-    data::NTuple{48, UInt8}
+    data::NTuple{48,UInt8}
 end
 
 function Base.getproperty(x::Ptr{pthread_cond_t}, f::Symbol)
     f === :__data && return Ptr{__JL_Ctag_1196}(x + 0)
-    f === :__size && return Ptr{NTuple{48, Cchar}}(x + 0)
+    f === :__size && return Ptr{NTuple{48,Cchar}}(x + 0)
     f === :__align && return Ptr{Clonglong}(x + 0)
     return getfield(x, f)
 end
@@ -109,12 +94,12 @@ const pthread_once_t = Cint
 Documentation not found.
 """
 struct pthread_rwlock_t
-    data::NTuple{32, UInt8}
+    data::NTuple{32,UInt8}
 end
 
 function Base.getproperty(x::Ptr{pthread_rwlock_t}, f::Symbol)
     f === :__data && return Ptr{__JL_Ctag_1197}(x + 0)
-    f === :__size && return Ptr{NTuple{32, Cchar}}(x + 0)
+    f === :__size && return Ptr{NTuple{32,Cchar}}(x + 0)
     f === :__align && return Ptr{Clong}(x + 0)
     return getfield(x, f)
 end
@@ -155,7 +140,7 @@ end
 Documentation not found.
 """
 struct sigval
-    data::NTuple{4, UInt8}
+    data::NTuple{4,UInt8}
 end
 
 function Base.getproperty(x::Ptr{sigval}, f::Symbol)
@@ -186,11 +171,11 @@ const sigval_t = sigval
 Documentation not found.
 """
 struct __JL_Ctag_1213
-    data::NTuple{116, UInt8}
+    data::NTuple{116,UInt8}
 end
 
 function Base.getproperty(x::Ptr{__JL_Ctag_1213}, f::Symbol)
-    f === :_pad && return Ptr{NTuple{29, Cint}}(x + 0)
+    f === :_pad && return Ptr{NTuple{29,Cint}}(x + 0)
     f === :_kill && return Ptr{__JL_Ctag_1214}(x + 0)
     f === :_timer && return Ptr{__JL_Ctag_1215}(x + 0)
     f === :_rt && return Ptr{__JL_Ctag_1216}(x + 0)
@@ -218,7 +203,7 @@ end
 Documentation not found.
 """
 struct siginfo_t
-    data::NTuple{128, UInt8}
+    data::NTuple{128,UInt8}
 end
 
 function Base.getproperty(x::Ptr{siginfo_t}, f::Symbol)
@@ -4777,7 +4762,7 @@ Documentation not found.
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
-    tz::NTuple{6, Cchar}
+    tz::NTuple{6,Cchar}
     gmt_time::tm
     local_time::tm
     utc_assumed::Bool
@@ -5554,7 +5539,7 @@ Documentation not found.
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
-    bytes::NTuple{1, UInt8}
+    bytes::NTuple{1,UInt8}
 end
 
 """
@@ -7908,7 +7893,7 @@ We separate the log level function from the log call itself so that we can do th
 By doing so, we make it so that the variadic format arguments are not even evaluated if the filter check does not succeed.
 """
 struct aws_logger_vtable
-    data::NTuple{16, UInt8}
+    data::NTuple{16,UInt8}
 end
 
 function Base.getproperty(x::Ptr{aws_logger_vtable}, f::Symbol)
@@ -8284,17 +8269,17 @@ end
 """
 Documentation not found.
 """
-const static_assertion_at_line_60 = NTuple{1, Cchar}
+const static_assertion_at_line_60 = NTuple{1,Cchar}
 
 """
 Documentation not found.
 """
-const static_assertion_at_line_61 = NTuple{1, Cchar}
+const static_assertion_at_line_61 = NTuple{1,Cchar}
 
 """
 Documentation not found.
 """
-const static_assertion_at_line_62 = NTuple{1, Cchar}
+const static_assertion_at_line_62 = NTuple{1,Cchar}
 
 """
     __JL_Ctag_665
@@ -10014,7 +9999,7 @@ Documentation not found.
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
-    _reserved::NTuple{8, Csize_t}
+    _reserved::NTuple{8,Csize_t}
 end
 
 """
@@ -10053,7 +10038,7 @@ const aws_task_fn = Cvoid
 honor the ABI compat
 """
 struct __JL_Ctag_1249
-    data::NTuple{4, UInt8}
+    data::NTuple{4,UInt8}
 end
 
 function Base.getproperty(x::Ptr{__JL_Ctag_1249}, f::Symbol)
@@ -10079,7 +10064,7 @@ end
 A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
 """
 struct aws_task
-    data::NTuple{40, UInt8}
+    data::NTuple{40,UInt8}
 end
 
 function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
@@ -11033,7 +11018,7 @@ end
 Documentation not found.
 """
 struct aws_uuid
-    uuid_data::NTuple{16, UInt8}
+    uuid_data::NTuple{16,UInt8}
 end
 
 """
@@ -11587,7 +11572,7 @@ end
 Documentation not found.
 """
 struct __pthread_mutex_s
-    data::NTuple{24, UInt8}
+    data::NTuple{24,UInt8}
 end
 
 function Base.getproperty(x::Ptr{__pthread_mutex_s}, f::Symbol)

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,53 +1,53 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const __uid_t = Cuint
 
 """
-Documentation not found
+Documentation not found.
 """
 const __pid_t = Cint
 
 """
-Documentation not found
+Documentation not found.
 """
 const __clock_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const __time_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = __time_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = Culong
 
 """
     __pthread_internal_slist
 
-Documentation not found
+Documentation not found.
 """
 struct __pthread_internal_slist
     __next::Ptr{__pthread_internal_slist}
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const __pthread_slist_t = __pthread_internal_slist
 
 """
     pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_mutex_t
     data::NTuple{24, UInt8}
@@ -74,7 +74,7 @@ end
 """
     pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_cond_t
     data::NTuple{48, UInt8}
@@ -99,14 +99,14 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = Cint
 
 """
     pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_rwlock_t
     data::NTuple{32, UInt8}
@@ -133,7 +133,7 @@ end
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -152,7 +152,7 @@ end
 """
     sigval
 
-Documentation not found
+Documentation not found.
 """
 struct sigval
     data::NTuple{4, UInt8}
@@ -176,14 +176,14 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const sigval_t = sigval
 
 """
     __JL_Ctag_1213
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1213
     data::NTuple{116, UInt8}
@@ -215,7 +215,7 @@ end
 """
     siginfo_t
 
-Documentation not found
+Documentation not found.
 """
 struct siginfo_t
     data::NTuple{128, UInt8}
@@ -270,7 +270,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -674,7 +674,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -687,7 +687,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -700,7 +700,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -713,7 +713,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -740,7 +740,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -753,7 +753,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -766,7 +766,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -779,7 +779,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -960,7 +960,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -973,7 +973,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -986,7 +986,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -999,7 +999,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -1012,7 +1012,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -1025,7 +1025,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -1038,7 +1038,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1051,7 +1051,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1064,7 +1064,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1077,7 +1077,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1090,7 +1090,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1103,7 +1103,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1116,7 +1116,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1129,7 +1129,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1142,7 +1142,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1155,7 +1155,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1168,7 +1168,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1181,7 +1181,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1194,7 +1194,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1207,7 +1207,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1220,7 +1220,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1233,7 +1233,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1246,7 +1246,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1259,7 +1259,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1272,7 +1272,7 @@ end
 """
     __JL_Ctag_39
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_39::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1281,7 +1281,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1670,7 +1670,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1681,7 +1681,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2122,7 +2122,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2379,7 +2379,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2476,7 +2476,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3103,7 +3103,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3116,7 +3116,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3129,7 +3129,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3142,7 +3142,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3155,7 +3155,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3686,7 +3686,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3710,7 +3710,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -4030,7 +4030,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4075,7 +4075,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4106,7 +4106,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4167,7 +4167,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4180,7 +4180,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4193,7 +4193,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4206,7 +4206,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4305,7 +4305,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4373,7 +4373,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4450,13 +4450,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4498,7 +4498,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4510,14 +4510,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4583,7 +4583,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4649,7 +4649,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4678,7 +4678,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4715,7 +4715,7 @@ end
 """
     __JL_Ctag_283
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_283::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4725,7 +4725,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4737,7 +4737,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4757,7 +4757,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4772,7 +4772,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4920,7 +4920,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4933,7 +4933,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4946,7 +4946,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4959,7 +4959,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4972,7 +4972,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4985,7 +4985,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4998,7 +4998,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -5011,7 +5011,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -5024,7 +5024,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -5037,7 +5037,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5050,7 +5050,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5399,7 +5399,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5440,7 +5440,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5452,10 +5452,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5467,7 +5467,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5478,7 +5478,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5493,7 +5493,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5506,7 +5506,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5549,7 +5549,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5602,7 +5602,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5615,7 +5615,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5624,7 +5624,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5785,7 +5785,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5826,7 +5826,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5923,14 +5923,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5941,7 +5941,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6181,7 +6181,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6259,7 +6259,7 @@ end
 """
     __JL_Ctag_429
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_429::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6282,7 +6282,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6293,7 +6293,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6419,7 +6419,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6437,7 +6437,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6649,7 +6649,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6744,7 +6744,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6755,10 +6755,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6776,10 +6776,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6797,9 +6797,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6817,10 +6817,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6838,9 +6838,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6858,9 +6858,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6876,10 +6876,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6895,10 +6895,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6914,10 +6914,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6935,11 +6935,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6955,10 +6955,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6974,10 +6974,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6993,10 +6993,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -7018,11 +7018,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -7040,10 +7040,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7059,10 +7059,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7078,9 +7078,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7096,10 +7096,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7121,11 +7121,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7141,11 +7141,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7161,9 +7161,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7179,9 +7179,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7197,9 +7197,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7215,9 +7215,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7233,9 +7233,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7251,9 +7251,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7269,9 +7269,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7289,7 +7289,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7309,10 +7309,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7332,10 +7332,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7351,10 +7351,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7528,7 +7528,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7611,20 +7611,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7633,20 +7633,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7728,20 +7728,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7764,7 +7764,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7791,7 +7791,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7837,7 +7837,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7933,7 +7933,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7978,7 +7978,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7989,7 +7989,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -7999,7 +7999,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8059,10 +8059,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8092,10 +8092,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8137,7 +8137,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8282,24 +8282,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_665
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_665::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8384,7 +8384,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8395,7 +8395,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8624,7 +8624,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8640,9 +8640,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8656,7 +8656,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8667,7 +8667,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8678,7 +8678,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8736,7 +8736,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8749,7 +8749,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8934,7 +8934,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8952,7 +8952,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8964,7 +8964,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8982,9 +8982,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -9000,9 +9000,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9157,7 +9157,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9208,7 +9208,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9235,7 +9235,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9262,7 +9262,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9273,7 +9273,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9407,7 +9407,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9498,7 +9500,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9609,7 +9611,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9711,7 +9713,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9722,7 +9724,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9730,7 +9732,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9753,7 +9755,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9766,7 +9768,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -10007,7 +10009,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -10032,7 +10034,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10105,7 +10107,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10173,7 +10175,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10272,7 +10274,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10304,7 +10306,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10314,14 +10316,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10346,7 +10348,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10520,7 +10522,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10599,7 +10601,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10811,7 +10813,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -11028,7 +11030,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11046,7 +11048,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11059,7 +11061,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11072,7 +11074,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11085,7 +11087,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11096,14 +11098,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11125,7 +11127,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11426,26 +11428,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11459,7 +11461,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11472,7 +11474,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -11485,7 +11487,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11498,7 +11500,7 @@ end
 """
     __JL_Ctag_1196
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1196
     __lock::Cint
@@ -11537,7 +11539,7 @@ end
 """
     __JL_Ctag_1197
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1197
     __lock::Cint
@@ -11582,7 +11584,7 @@ end
 """
     __pthread_mutex_s
 
-Documentation not found
+Documentation not found.
 """
 struct __pthread_mutex_s
     data::NTuple{24, UInt8}
@@ -11613,7 +11615,7 @@ end
 """
     __JL_Ctag_1214
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1214
     si_pid::__pid_t
@@ -11640,7 +11642,7 @@ end
 """
     __JL_Ctag_1215
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1215
     si_tid::Cint
@@ -11669,7 +11671,7 @@ end
 """
     __JL_Ctag_1216
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1216
     si_pid::__pid_t
@@ -11698,7 +11700,7 @@ end
 """
     __JL_Ctag_1217
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1217
     si_pid::__pid_t
@@ -11731,7 +11733,7 @@ end
 """
     __JL_Ctag_1218
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1218
     si_addr::Ptr{Cvoid}
@@ -11758,7 +11760,7 @@ end
 """
     __JL_Ctag_1219
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1219
     si_band::Clong
@@ -11785,7 +11787,7 @@ end
 """
     __JL_Ctag_1220
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1220
     _call_addr::Ptr{Cvoid}
@@ -11812,84 +11814,84 @@ end
 
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11900,37 +11902,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 32
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11941,32 +11943,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -3,6 +3,21 @@ using CEnum
 """
 Documentation not found.
 """
+const __uid_t = Cuint
+
+"""
+Documentation not found.
+"""
+const __pid_t = Cint
+
+"""
+Documentation not found.
+"""
+const __clock_t = Clong
+
+"""
+Documentation not found.
+"""
 const __time_t = Clong
 
 """
@@ -35,12 +50,12 @@ const __pthread_slist_t = __pthread_internal_slist
 Documentation not found.
 """
 struct pthread_mutex_t
-    data::NTuple{24,UInt8}
+    data::NTuple{24, UInt8}
 end
 
 function Base.getproperty(x::Ptr{pthread_mutex_t}, f::Symbol)
     f === :__data && return Ptr{__pthread_mutex_s}(x + 0)
-    f === :__size && return Ptr{NTuple{24,Cchar}}(x + 0)
+    f === :__size && return Ptr{NTuple{24, Cchar}}(x + 0)
     f === :__align && return Ptr{Clong}(x + 0)
     return getfield(x, f)
 end
@@ -62,12 +77,12 @@ end
 Documentation not found.
 """
 struct pthread_cond_t
-    data::NTuple{48,UInt8}
+    data::NTuple{48, UInt8}
 end
 
 function Base.getproperty(x::Ptr{pthread_cond_t}, f::Symbol)
     f === :__data && return Ptr{__JL_Ctag_1196}(x + 0)
-    f === :__size && return Ptr{NTuple{48,Cchar}}(x + 0)
+    f === :__size && return Ptr{NTuple{48, Cchar}}(x + 0)
     f === :__align && return Ptr{Clonglong}(x + 0)
     return getfield(x, f)
 end
@@ -94,12 +109,12 @@ const pthread_once_t = Cint
 Documentation not found.
 """
 struct pthread_rwlock_t
-    data::NTuple{32,UInt8}
+    data::NTuple{32, UInt8}
 end
 
 function Base.getproperty(x::Ptr{pthread_rwlock_t}, f::Symbol)
     f === :__data && return Ptr{__JL_Ctag_1197}(x + 0)
-    f === :__size && return Ptr{NTuple{32,Cchar}}(x + 0)
+    f === :__size && return Ptr{NTuple{32, Cchar}}(x + 0)
     f === :__align && return Ptr{Clong}(x + 0)
     return getfield(x, f)
 end
@@ -140,7 +155,7 @@ end
 Documentation not found.
 """
 struct sigval
-    data::NTuple{4,UInt8}
+    data::NTuple{4, UInt8}
 end
 
 function Base.getproperty(x::Ptr{sigval}, f::Symbol)
@@ -171,11 +186,11 @@ const sigval_t = sigval
 Documentation not found.
 """
 struct __JL_Ctag_1213
-    data::NTuple{116,UInt8}
+    data::NTuple{116, UInt8}
 end
 
 function Base.getproperty(x::Ptr{__JL_Ctag_1213}, f::Symbol)
-    f === :_pad && return Ptr{NTuple{29,Cint}}(x + 0)
+    f === :_pad && return Ptr{NTuple{29, Cint}}(x + 0)
     f === :_kill && return Ptr{__JL_Ctag_1214}(x + 0)
     f === :_timer && return Ptr{__JL_Ctag_1215}(x + 0)
     f === :_rt && return Ptr{__JL_Ctag_1216}(x + 0)
@@ -203,7 +218,7 @@ end
 Documentation not found.
 """
 struct siginfo_t
-    data::NTuple{128,UInt8}
+    data::NTuple{128, UInt8}
 end
 
 function Base.getproperty(x::Ptr{siginfo_t}, f::Symbol)
@@ -4762,7 +4777,7 @@ Documentation not found.
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
-    tz::NTuple{6,Cchar}
+    tz::NTuple{6, Cchar}
     gmt_time::tm
     local_time::tm
     utc_assumed::Bool
@@ -5539,7 +5554,7 @@ Documentation not found.
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
-    bytes::NTuple{1,UInt8}
+    bytes::NTuple{1, UInt8}
 end
 
 """
@@ -7893,7 +7908,7 @@ We separate the log level function from the log call itself so that we can do th
 By doing so, we make it so that the variadic format arguments are not even evaluated if the filter check does not succeed.
 """
 struct aws_logger_vtable
-    data::NTuple{16,UInt8}
+    data::NTuple{16, UInt8}
 end
 
 function Base.getproperty(x::Ptr{aws_logger_vtable}, f::Symbol)
@@ -8269,17 +8284,17 @@ end
 """
 Documentation not found.
 """
-const static_assertion_at_line_60 = NTuple{1,Cchar}
+const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
 Documentation not found.
 """
-const static_assertion_at_line_61 = NTuple{1,Cchar}
+const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
 Documentation not found.
 """
-const static_assertion_at_line_62 = NTuple{1,Cchar}
+const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_665
@@ -9999,7 +10014,7 @@ Documentation not found.
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
-    _reserved::NTuple{8,Csize_t}
+    _reserved::NTuple{8, Csize_t}
 end
 
 """
@@ -10038,7 +10053,7 @@ const aws_task_fn = Cvoid
 honor the ABI compat
 """
 struct __JL_Ctag_1249
-    data::NTuple{4,UInt8}
+    data::NTuple{4, UInt8}
 end
 
 function Base.getproperty(x::Ptr{__JL_Ctag_1249}, f::Symbol)
@@ -10064,7 +10079,7 @@ end
 A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
 """
 struct aws_task
-    data::NTuple{40,UInt8}
+    data::NTuple{40, UInt8}
 end
 
 function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
@@ -11018,7 +11033,7 @@ end
 Documentation not found.
 """
 struct aws_uuid
-    uuid_data::NTuple{16,UInt8}
+    uuid_data::NTuple{16, UInt8}
 end
 
 """
@@ -11572,7 +11587,7 @@ end
 Documentation not found.
 """
 struct __pthread_mutex_s
-    data::NTuple{24,UInt8}
+    data::NTuple{24, UInt8}
 end
 
 function Base.getproperty(x::Ptr{__pthread_mutex_s}, f::Symbol)

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,23 +1,54 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const __uid_t = Cuint
 
+"""
+Documentation not found
+"""
 const __pid_t = Cint
 
+"""
+Documentation not found
+"""
 const __clock_t = Clong
 
+"""
+Documentation not found
+"""
 const __time_t = Clong
 
+"""
+Documentation not found
+"""
 const time_t = __time_t
 
+"""
+Documentation not found
+"""
 const pthread_t = Culong
 
+"""
+    __pthread_internal_slist
+
+Documentation not found
+"""
 struct __pthread_internal_slist
     __next::Ptr{__pthread_internal_slist}
 end
 
+"""
+Documentation not found
+"""
 const __pthread_slist_t = __pthread_internal_slist
 
+"""
+    pthread_mutex_t
+
+Documentation not found
+"""
 struct pthread_mutex_t
     data::NTuple{24, UInt8}
 end
@@ -40,6 +71,11 @@ function Base.setproperty!(x::Ptr{pthread_mutex_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_cond_t
+
+Documentation not found
+"""
 struct pthread_cond_t
     data::NTuple{48, UInt8}
 end
@@ -62,8 +98,16 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const pthread_once_t = Cint
 
+"""
+    pthread_rwlock_t
+
+Documentation not found
+"""
 struct pthread_rwlock_t
     data::NTuple{32, UInt8}
 end
@@ -86,6 +130,11 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -100,6 +149,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    sigval
+
+Documentation not found
+"""
 struct sigval
     data::NTuple{4, UInt8}
 end
@@ -121,8 +175,16 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const sigval_t = sigval
 
+"""
+    __JL_Ctag_1213
+
+Documentation not found
+"""
 struct __JL_Ctag_1213
     data::NTuple{116, UInt8}
 end
@@ -150,6 +212,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1213}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    siginfo_t
+
+Documentation not found
+"""
 struct siginfo_t
     data::NTuple{128, UInt8}
 end
@@ -173,6 +240,11 @@ function Base.setproperty!(x::Ptr{siginfo_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -198,6 +270,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -209,6 +282,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -277,6 +352,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -285,6 +365,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -298,6 +380,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -309,6 +393,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -322,6 +408,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -333,6 +421,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -346,6 +436,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -357,6 +449,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -370,6 +464,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -381,6 +477,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -394,6 +492,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -406,6 +506,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -417,6 +519,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -570,6 +674,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -582,6 +687,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -594,6 +700,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -606,6 +713,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -632,6 +740,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -644,6 +753,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -656,6 +766,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -668,6 +779,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -848,6 +960,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -860,6 +973,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -872,6 +986,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -884,6 +999,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -896,6 +1012,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -908,6 +1025,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -920,6 +1038,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -932,6 +1051,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -944,6 +1064,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -956,6 +1077,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -968,6 +1090,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -980,6 +1103,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -992,6 +1116,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1004,6 +1129,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1016,6 +1142,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1028,6 +1155,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1040,6 +1168,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1052,6 +1181,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1064,6 +1194,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1076,6 +1207,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1088,6 +1220,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1100,6 +1233,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1112,6 +1246,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1124,6 +1259,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1133,10 +1269,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_39
+
+Documentation not found
+"""
 @cenum __JL_Ctag_39::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1524,6 +1670,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1533,6 +1680,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1544,6 +1694,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1965,6 +2122,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2221,6 +2379,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2317,6 +2476,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2943,6 +3103,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2955,6 +3116,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2967,6 +3129,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2979,6 +3142,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2991,6 +3155,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3518,6 +3683,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3537,6 +3707,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3855,6 +4030,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3896,6 +4072,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3922,6 +4103,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3967,6 +4153,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3979,6 +4167,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3991,6 +4180,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4003,6 +4193,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4015,6 +4206,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4110,6 +4302,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4173,6 +4370,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4195,6 +4397,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4289,6 +4498,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4299,8 +4509,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4362,6 +4580,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4423,6 +4646,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4449,6 +4677,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4481,11 +4712,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_283
+
+Documentation not found
+"""
 @cenum __JL_Ctag_283::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4493,6 +4734,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4508,6 +4754,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4518,6 +4769,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4664,6 +4920,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4676,6 +4933,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4688,6 +4946,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4700,6 +4959,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4712,6 +4972,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4724,6 +4985,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4736,6 +4998,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4748,6 +5011,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4760,6 +5024,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4772,6 +5037,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4784,6 +5050,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4894,6 +5161,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4905,6 +5174,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4918,6 +5189,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4929,6 +5202,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4942,6 +5217,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4953,6 +5230,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4966,6 +5245,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4977,6 +5258,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4990,6 +5273,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -5001,6 +5286,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -5014,6 +5301,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5025,6 +5314,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5038,6 +5329,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5049,6 +5342,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5062,6 +5357,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5073,6 +5370,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5086,6 +5385,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5095,6 +5396,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5105,6 +5411,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5118,6 +5426,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5127,6 +5437,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5151,6 +5466,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5175,6 +5493,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5187,6 +5506,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5226,6 +5546,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5234,6 +5559,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5247,6 +5574,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5259,6 +5588,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5268,6 +5599,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5276,16 +5612,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5299,6 +5645,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5310,6 +5658,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5323,6 +5673,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5334,6 +5686,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5347,6 +5701,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5358,6 +5714,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5371,6 +5729,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5383,6 +5743,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5394,6 +5756,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5421,6 +5785,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5458,6 +5823,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5552,14 +5922,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5840,6 +6223,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5852,6 +6243,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5861,6 +6256,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_429
+
+Documentation not found
+"""
 @cenum __JL_Ctag_429::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5879,12 +6279,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6239,6 +6649,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6332,6 +6743,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7196,33 +7610,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7232,6 +7682,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7245,6 +7699,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7257,6 +7715,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7267,22 +7727,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7305,6 +7788,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7319,6 +7807,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7331,6 +7823,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7340,6 +7834,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7347,6 +7846,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7360,6 +7861,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7372,6 +7875,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7383,6 +7888,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7423,6 +7930,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7454,21 +7966,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_645
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_645::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7482,6 +8014,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7597,6 +8136,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7658,6 +8200,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7670,6 +8214,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7681,6 +8227,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7733,12 +8281,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_665
+
+Documentation not found
+"""
 @cenum __JL_Ctag_665::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7814,14 +8376,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8078,12 +8653,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8151,6 +8736,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8163,6 +8749,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8186,10 +8773,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8203,6 +8795,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8214,6 +8808,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8227,6 +8823,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8238,6 +8836,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8251,6 +8851,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8262,6 +8864,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8275,6 +8879,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8286,6 +8892,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8299,6 +8907,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8311,6 +8921,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8321,14 +8933,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8419,6 +9044,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8527,6 +9154,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8576,6 +9208,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8602,6 +9235,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8628,6 +9262,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8637,8 +9272,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_861
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_861::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8676,12 +9319,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8846,6 +9498,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9055,17 +9708,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9087,6 +9753,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9099,6 +9766,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9171,6 +9839,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9182,6 +9852,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9237,6 +9909,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9248,6 +9922,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9261,6 +9937,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9273,6 +9951,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9284,6 +9964,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9311,6 +9993,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9320,6 +10004,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9328,6 +10017,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9338,6 +10029,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9349,6 +10045,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_1249
+
+honor the ABI compat
+"""
 struct __JL_Ctag_1249
     data::NTuple{4, UInt8}
 end
@@ -9370,6 +10071,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1249}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{40, UInt8}
 end
@@ -9396,6 +10102,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9419,6 +10130,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9460,6 +10173,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9555,6 +10269,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9582,6 +10301,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9589,8 +10313,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9614,6 +10346,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9786,6 +10519,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9862,6 +10598,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10072,6 +10811,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10285,10 +11025,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_1090
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_1090::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10296,6 +11046,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10308,6 +11059,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10320,6 +11072,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10332,6 +11085,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10341,8 +11095,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10360,6 +11122,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10412,6 +11179,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10424,6 +11193,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10435,6 +11206,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10652,14 +11425,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10672,6 +11459,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10684,6 +11472,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -10696,6 +11485,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10705,6 +11495,11 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+    __JL_Ctag_1196
+
+Documentation not found
+"""
 struct __JL_Ctag_1196
     __lock::Cint
     __futex::Cuint
@@ -10739,6 +11534,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1196}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1197
+
+Documentation not found
+"""
 struct __JL_Ctag_1197
     __lock::Cint
     __nr_readers::Cuint
@@ -10779,6 +11579,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1197}, f::Symbol, v)
 end
 
 
+"""
+    __pthread_mutex_s
+
+Documentation not found
+"""
 struct __pthread_mutex_s
     data::NTuple{24, UInt8}
 end
@@ -10805,6 +11610,11 @@ function Base.setproperty!(x::Ptr{__pthread_mutex_s}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __JL_Ctag_1214
+
+Documentation not found
+"""
 struct __JL_Ctag_1214
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10827,6 +11637,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1214}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1215
+
+Documentation not found
+"""
 struct __JL_Ctag_1215
     si_tid::Cint
     si_overrun::Cint
@@ -10851,6 +11666,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1215}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1216
+
+Documentation not found
+"""
 struct __JL_Ctag_1216
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10875,6 +11695,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1216}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1217
+
+Documentation not found
+"""
 struct __JL_Ctag_1217
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10903,6 +11728,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1217}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1218
+
+Documentation not found
+"""
 struct __JL_Ctag_1218
     si_addr::Ptr{Cvoid}
     si_addr_lsb::Cshort
@@ -10925,6 +11755,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1218}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1219
+
+Documentation not found
+"""
 struct __JL_Ctag_1219
     si_band::Clong
     si_fd::Cint
@@ -10947,6 +11782,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1219}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1220
+
+Documentation not found
+"""
 struct __JL_Ctag_1220
     _call_addr::Ptr{Cvoid}
     _syscall::Cint
@@ -10971,38 +11811,86 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1220}, f::Symbol, v)
 end
 
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -11011,18 +11899,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 32
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -11031,15 +11940,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,14 +1,14 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = Clong
 
 """
     __JL_Ctag_328
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_328
     data::NTuple{24, UInt8}
@@ -35,7 +35,7 @@ end
 """
     pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_mutex_t
     data::NTuple{24, UInt8}
@@ -60,7 +60,7 @@ end
 """
     __JL_Ctag_324
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_324
     data::NTuple{48, UInt8}
@@ -87,7 +87,7 @@ end
 """
     pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_cond_t
     data::NTuple{48, UInt8}
@@ -112,7 +112,7 @@ end
 """
     __JL_Ctag_331
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_331
     data::NTuple{32, UInt8}
@@ -139,7 +139,7 @@ end
 """
     pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_rwlock_t
     data::NTuple{32, UInt8}
@@ -162,24 +162,24 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct __pthread end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = Ptr{__pthread}
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = Cint
 
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -225,7 +225,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -629,7 +629,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -642,7 +642,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -655,7 +655,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -668,7 +668,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -695,7 +695,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -708,7 +708,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -721,7 +721,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -734,7 +734,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -915,7 +915,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -928,7 +928,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -941,7 +941,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -954,7 +954,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -967,7 +967,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -980,7 +980,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -993,7 +993,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1006,7 +1006,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1019,7 +1019,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1032,7 +1032,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1045,7 +1045,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1058,7 +1058,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1071,7 +1071,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1084,7 +1084,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1097,7 +1097,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1110,7 +1110,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1123,7 +1123,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1136,7 +1136,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1149,7 +1149,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1162,7 +1162,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1175,7 +1175,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1188,7 +1188,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1201,7 +1201,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1214,7 +1214,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1227,7 +1227,7 @@ end
 """
     __JL_Ctag_9
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_9::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1236,7 +1236,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1625,7 +1625,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1636,7 +1636,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2077,7 +2077,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2334,7 +2334,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2431,7 +2431,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3058,7 +3058,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3071,7 +3071,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3084,7 +3084,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3097,7 +3097,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3110,7 +3110,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3641,7 +3641,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3665,7 +3665,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -3985,7 +3985,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4030,7 +4030,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4061,7 +4061,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4122,7 +4122,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4135,7 +4135,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4148,7 +4148,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4161,7 +4161,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4260,7 +4260,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4328,7 +4328,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4405,13 +4405,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4453,7 +4453,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4465,14 +4465,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4538,7 +4538,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4604,7 +4604,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4633,7 +4633,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4670,7 +4670,7 @@ end
 """
     __JL_Ctag_66
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_66::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4680,7 +4680,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4692,7 +4692,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4712,7 +4712,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4727,7 +4727,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4875,7 +4875,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4888,7 +4888,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4901,7 +4901,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4914,7 +4914,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4927,7 +4927,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4940,7 +4940,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4953,7 +4953,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4966,7 +4966,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4979,7 +4979,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4992,7 +4992,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5005,7 +5005,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5354,7 +5354,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5395,7 +5395,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5407,10 +5407,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5422,7 +5422,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5433,7 +5433,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5448,7 +5448,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5461,7 +5461,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5504,7 +5504,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5557,7 +5557,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5570,7 +5570,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5579,7 +5579,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5740,7 +5740,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5781,7 +5781,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5878,14 +5878,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5896,7 +5896,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6136,7 +6136,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6214,7 +6214,7 @@ end
 """
     __JL_Ctag_97
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_97::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6237,7 +6237,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6248,7 +6248,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6374,7 +6374,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6392,7 +6392,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6604,7 +6604,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6699,7 +6699,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6710,10 +6710,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6731,10 +6731,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6752,9 +6752,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6772,10 +6772,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6793,9 +6793,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6813,9 +6813,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6831,10 +6831,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6850,10 +6850,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6869,10 +6869,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6890,11 +6890,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6910,10 +6910,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6929,10 +6929,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6948,10 +6948,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -6973,11 +6973,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -6995,10 +6995,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7014,10 +7014,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7033,9 +7033,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7051,10 +7051,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7076,11 +7076,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7096,11 +7096,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7116,9 +7116,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7134,9 +7134,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7152,9 +7152,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7170,9 +7170,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7188,9 +7188,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7206,9 +7206,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7224,9 +7224,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7244,7 +7244,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7264,10 +7264,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7287,10 +7287,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7306,10 +7306,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7483,7 +7483,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7566,20 +7566,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7588,20 +7588,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7683,20 +7683,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7719,7 +7719,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7746,7 +7746,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7792,7 +7792,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7888,7 +7888,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7933,7 +7933,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7944,7 +7944,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -7954,7 +7954,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8014,10 +8014,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8047,10 +8047,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8092,7 +8092,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8237,24 +8237,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_166
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_166::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8339,7 +8339,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8350,7 +8350,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8579,7 +8579,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8595,9 +8595,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8611,7 +8611,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8622,7 +8622,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8633,7 +8633,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8691,7 +8691,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8704,7 +8704,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8889,7 +8889,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8907,7 +8907,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8919,7 +8919,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8937,9 +8937,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -8955,9 +8955,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9112,7 +9112,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9163,7 +9163,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9190,7 +9190,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9217,7 +9217,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9228,7 +9228,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9362,7 +9362,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9453,7 +9455,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9564,7 +9566,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9666,7 +9668,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9677,7 +9679,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9685,7 +9687,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9708,7 +9710,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9721,7 +9723,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9962,7 +9964,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -9987,7 +9989,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10060,7 +10062,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10128,7 +10130,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10227,7 +10229,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10259,7 +10261,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10269,14 +10271,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10301,7 +10303,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10475,7 +10477,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10554,7 +10556,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10766,7 +10768,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10983,7 +10985,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11001,7 +11003,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11014,7 +11016,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11027,7 +11029,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11040,7 +11042,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11051,14 +11053,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11080,7 +11082,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11381,26 +11383,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11414,7 +11416,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11427,7 +11429,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11438,84 +11440,84 @@ function enable_vt_mode()
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11526,37 +11528,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 32
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11567,32 +11569,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,7 +1,15 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const time_t = Clong
 
+"""
+    __JL_Ctag_328
+
+Documentation not found
+"""
 struct __JL_Ctag_328
     data::NTuple{24, UInt8}
 end
@@ -24,6 +32,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_328}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_mutex_t
+
+Documentation not found
+"""
 struct pthread_mutex_t
     data::NTuple{24, UInt8}
 end
@@ -44,6 +57,11 @@ function Base.setproperty!(x::Ptr{pthread_mutex_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __JL_Ctag_324
+
+Documentation not found
+"""
 struct __JL_Ctag_324
     data::NTuple{48, UInt8}
 end
@@ -66,6 +84,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_324}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_cond_t
+
+Documentation not found
+"""
 struct pthread_cond_t
     data::NTuple{48, UInt8}
 end
@@ -86,6 +109,11 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __JL_Ctag_331
+
+Documentation not found
+"""
 struct __JL_Ctag_331
     data::NTuple{32, UInt8}
 end
@@ -108,6 +136,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_331}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_rwlock_t
+
+Documentation not found
+"""
 struct pthread_rwlock_t
     data::NTuple{32, UInt8}
 end
@@ -128,12 +161,26 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 mutable struct __pthread end
 
+"""
+Documentation not found
+"""
 const pthread_t = Ptr{__pthread}
 
+"""
+Documentation not found
+"""
 const pthread_once_t = Cint
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -148,6 +195,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -173,6 +225,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -184,6 +237,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -252,6 +307,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -260,6 +320,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -273,6 +335,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -284,6 +348,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -297,6 +363,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -308,6 +376,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -321,6 +391,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -332,6 +404,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -345,6 +419,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -356,6 +432,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -369,6 +447,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -381,6 +461,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -392,6 +474,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -545,6 +629,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -557,6 +642,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -569,6 +655,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -581,6 +668,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -607,6 +695,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -619,6 +708,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -631,6 +721,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -643,6 +734,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -823,6 +915,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -835,6 +928,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -847,6 +941,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -859,6 +954,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -871,6 +967,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -883,6 +980,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -895,6 +993,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -907,6 +1006,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -919,6 +1019,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -931,6 +1032,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -943,6 +1045,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -955,6 +1058,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -967,6 +1071,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -979,6 +1084,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -991,6 +1097,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1003,6 +1110,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1015,6 +1123,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1027,6 +1136,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1039,6 +1149,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1051,6 +1162,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1063,6 +1175,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1075,6 +1188,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1087,6 +1201,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1099,6 +1214,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1108,10 +1224,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_9
+
+Documentation not found
+"""
 @cenum __JL_Ctag_9::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1499,6 +1625,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1508,6 +1635,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1519,6 +1649,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1940,6 +2077,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2196,6 +2334,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2292,6 +2431,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2918,6 +3058,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2930,6 +3071,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2942,6 +3084,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2954,6 +3097,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2966,6 +3110,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3493,6 +3638,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3512,6 +3662,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3830,6 +3985,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3871,6 +4027,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3897,6 +4058,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3942,6 +4108,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3954,6 +4122,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3966,6 +4135,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -3978,6 +4148,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -3990,6 +4161,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4085,6 +4257,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4148,6 +4325,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4170,6 +4352,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4264,6 +4453,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4274,8 +4464,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4337,6 +4535,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4398,6 +4601,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4424,6 +4632,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4456,11 +4667,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_66
+
+Documentation not found
+"""
 @cenum __JL_Ctag_66::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4468,6 +4689,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4483,6 +4709,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4493,6 +4724,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4639,6 +4875,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4651,6 +4888,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4663,6 +4901,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4675,6 +4914,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4687,6 +4927,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4699,6 +4940,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4711,6 +4953,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4723,6 +4966,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4735,6 +4979,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4747,6 +4992,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4759,6 +5005,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4869,6 +5116,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4880,6 +5129,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4893,6 +5144,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4904,6 +5157,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4917,6 +5172,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4928,6 +5185,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4941,6 +5200,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4952,6 +5213,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4965,6 +5228,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4976,6 +5241,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -4989,6 +5256,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5000,6 +5269,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5013,6 +5284,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5024,6 +5297,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5037,6 +5312,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5048,6 +5325,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5061,6 +5340,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5070,6 +5351,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5080,6 +5366,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5093,6 +5381,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5102,6 +5392,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5126,6 +5421,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5150,6 +5448,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5162,6 +5461,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5201,6 +5501,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5209,6 +5514,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5222,6 +5529,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5234,6 +5543,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5243,6 +5554,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5251,16 +5567,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5274,6 +5600,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5285,6 +5613,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5298,6 +5628,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5309,6 +5641,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5322,6 +5656,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5333,6 +5669,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5346,6 +5684,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5358,6 +5698,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5369,6 +5711,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5396,6 +5740,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5433,6 +5778,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5527,14 +5877,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5815,6 +6178,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5827,6 +6198,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5836,6 +6211,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_97
+
+Documentation not found
+"""
 @cenum __JL_Ctag_97::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5854,12 +6234,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6214,6 +6604,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6307,6 +6698,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7171,33 +7565,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7207,6 +7637,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7220,6 +7654,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7232,6 +7670,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7242,22 +7682,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7280,6 +7743,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7294,6 +7762,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7306,6 +7778,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7315,6 +7789,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7322,6 +7801,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7335,6 +7816,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7347,6 +7830,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7358,6 +7843,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7398,6 +7885,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7429,21 +7921,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_161
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_161::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7457,6 +7969,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7572,6 +8091,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7633,6 +8155,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7645,6 +8169,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7656,6 +8182,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7708,12 +8236,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_166
+
+Documentation not found
+"""
 @cenum __JL_Ctag_166::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7789,14 +8331,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8053,12 +8608,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8126,6 +8691,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8138,6 +8704,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8161,10 +8728,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8178,6 +8750,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8189,6 +8763,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8202,6 +8778,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8213,6 +8791,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8226,6 +8806,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8237,6 +8819,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8250,6 +8834,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8261,6 +8847,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8274,6 +8862,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8286,6 +8876,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8296,14 +8888,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8394,6 +8999,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8502,6 +9109,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8551,6 +9163,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8577,6 +9190,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8603,6 +9217,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8612,8 +9227,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_221
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_221::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8651,12 +9274,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8821,6 +9453,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9030,17 +9663,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9062,6 +9708,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9074,6 +9721,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9146,6 +9794,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9157,6 +9807,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9212,6 +9864,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9223,6 +9877,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9236,6 +9892,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9248,6 +9906,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9259,6 +9919,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9286,6 +9948,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9295,6 +9959,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9303,6 +9972,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9313,6 +9984,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9324,6 +10000,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_320
+
+honor the ABI compat
+"""
 struct __JL_Ctag_320
     data::NTuple{4, UInt8}
 end
@@ -9345,6 +10026,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_320}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{40, UInt8}
 end
@@ -9371,6 +10057,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9394,6 +10085,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9435,6 +10128,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9530,6 +10224,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9557,6 +10256,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9564,8 +10268,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9589,6 +10301,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9761,6 +10474,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9837,6 +10553,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10047,6 +10766,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10260,10 +10980,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_275
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_275::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10271,6 +11001,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10283,6 +11014,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10295,6 +11027,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10307,6 +11040,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10316,8 +11050,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10335,6 +11077,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10387,6 +11134,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10399,6 +11148,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10410,6 +11161,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10627,14 +11380,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10647,6 +11414,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10659,6 +11427,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10668,38 +11437,86 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10708,18 +11525,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 32
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -10728,15 +11566,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,23 +1,54 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const __uid_t = Cuint
 
+"""
+Documentation not found
+"""
 const __pid_t = Cint
 
+"""
+Documentation not found
+"""
 const __clock_t = Clong
 
+"""
+Documentation not found
+"""
 const __time_t = Clong
 
+"""
+Documentation not found
+"""
 const time_t = __time_t
 
+"""
+Documentation not found
+"""
 const pthread_t = Culong
 
+"""
+    __pthread_internal_slist
+
+Documentation not found
+"""
 struct __pthread_internal_slist
     __next::Ptr{__pthread_internal_slist}
 end
 
+"""
+Documentation not found
+"""
 const __pthread_slist_t = __pthread_internal_slist
 
+"""
+    pthread_mutex_t
+
+Documentation not found
+"""
 struct pthread_mutex_t
     data::NTuple{24, UInt8}
 end
@@ -40,6 +71,11 @@ function Base.setproperty!(x::Ptr{pthread_mutex_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_cond_t
+
+Documentation not found
+"""
 struct pthread_cond_t
     data::NTuple{48, UInt8}
 end
@@ -62,8 +98,16 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const pthread_once_t = Cint
 
+"""
+    pthread_rwlock_t
+
+Documentation not found
+"""
 struct pthread_rwlock_t
     data::NTuple{32, UInt8}
 end
@@ -86,6 +130,11 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -100,6 +149,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    sigval
+
+Documentation not found
+"""
 struct sigval
     data::NTuple{4, UInt8}
 end
@@ -121,8 +175,16 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const sigval_t = sigval
 
+"""
+    __JL_Ctag_1307
+
+Documentation not found
+"""
 struct __JL_Ctag_1307
     data::NTuple{116, UInt8}
 end
@@ -149,6 +211,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1307}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    siginfo
+
+Documentation not found
+"""
 struct siginfo
     data::NTuple{128, UInt8}
 end
@@ -172,8 +239,16 @@ function Base.setproperty!(x::Ptr{siginfo}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const siginfo_t = siginfo
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -199,6 +274,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -210,6 +286,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -278,6 +356,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -286,6 +369,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -299,6 +384,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -310,6 +397,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -323,6 +412,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -334,6 +425,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -347,6 +440,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -358,6 +453,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -371,6 +468,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -382,6 +481,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -395,6 +496,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -407,6 +510,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -418,6 +523,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -571,6 +678,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -583,6 +691,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -595,6 +704,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -607,6 +717,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -633,6 +744,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -645,6 +757,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -657,6 +770,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -669,6 +783,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -849,6 +964,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -861,6 +977,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -873,6 +990,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -885,6 +1003,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -897,6 +1016,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -909,6 +1029,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -921,6 +1042,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -933,6 +1055,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -945,6 +1068,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -957,6 +1081,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -969,6 +1094,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -981,6 +1107,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -993,6 +1120,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1005,6 +1133,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1017,6 +1146,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1029,6 +1159,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1041,6 +1172,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1053,6 +1185,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1065,6 +1198,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1077,6 +1211,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1089,6 +1224,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1101,6 +1237,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1113,6 +1250,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1125,6 +1263,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1134,10 +1273,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_41
+
+Documentation not found
+"""
 @cenum __JL_Ctag_41::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1525,6 +1674,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1534,6 +1684,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1545,6 +1698,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1966,6 +2126,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2222,6 +2383,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2318,6 +2480,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2944,6 +3107,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2956,6 +3120,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2968,6 +3133,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2980,6 +3146,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2992,6 +3159,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3519,6 +3687,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3538,6 +3711,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3856,6 +4034,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3897,6 +4076,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3923,6 +4107,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3968,6 +4157,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3980,6 +4171,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3992,6 +4184,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4004,6 +4197,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4016,6 +4210,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4111,6 +4306,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4174,6 +4374,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4196,6 +4401,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4290,6 +4502,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4300,8 +4513,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4363,6 +4584,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4424,6 +4650,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4450,6 +4681,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4482,11 +4716,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_292
+
+Documentation not found
+"""
 @cenum __JL_Ctag_292::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4494,6 +4738,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4509,6 +4758,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4519,6 +4773,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4665,6 +4924,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4677,6 +4937,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4689,6 +4950,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4701,6 +4963,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4713,6 +4976,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4725,6 +4989,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4737,6 +5002,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4749,6 +5015,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4761,6 +5028,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4773,6 +5041,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4785,6 +5054,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4895,6 +5165,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4906,6 +5178,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4919,6 +5193,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4930,6 +5206,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4943,6 +5221,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4954,6 +5234,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4967,6 +5249,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4978,6 +5262,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4991,6 +5277,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -5002,6 +5290,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -5015,6 +5305,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5026,6 +5318,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5039,6 +5333,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5050,6 +5346,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5063,6 +5361,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5074,6 +5374,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5087,6 +5389,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5096,6 +5400,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5106,6 +5415,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5119,6 +5430,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5128,6 +5441,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5152,6 +5470,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5176,6 +5497,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5188,6 +5510,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5227,6 +5550,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5235,6 +5563,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5248,6 +5578,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5260,6 +5592,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5269,6 +5603,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5277,16 +5616,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5300,6 +5649,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5311,6 +5662,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5324,6 +5677,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5335,6 +5690,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5348,6 +5705,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5359,6 +5718,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5372,6 +5733,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5384,6 +5747,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5395,6 +5760,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5422,6 +5789,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5459,6 +5827,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5553,14 +5926,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5841,6 +6227,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5853,6 +6247,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5862,6 +6260,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_443
+
+Documentation not found
+"""
 @cenum __JL_Ctag_443::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5880,12 +6283,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6240,6 +6653,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6333,6 +6747,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7197,33 +7614,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7233,6 +7686,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7246,6 +7703,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7258,6 +7719,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7268,22 +7731,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7306,6 +7792,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7320,6 +7811,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7332,6 +7827,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7341,6 +7838,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7348,6 +7850,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7361,6 +7865,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7373,6 +7879,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7384,6 +7892,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7424,6 +7934,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7455,21 +7970,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_660
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_660::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7483,6 +8018,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7598,6 +8140,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7659,6 +8204,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7671,6 +8218,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7682,6 +8231,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7734,12 +8285,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_681
+
+Documentation not found
+"""
 @cenum __JL_Ctag_681::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7815,14 +8380,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8079,12 +8657,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8152,6 +8740,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8164,6 +8753,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8187,10 +8777,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8204,6 +8799,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8215,6 +8812,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8228,6 +8827,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8239,6 +8840,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8252,6 +8855,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8263,6 +8868,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8276,6 +8883,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8287,6 +8896,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8300,6 +8911,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8312,6 +8925,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8322,14 +8937,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8420,6 +9048,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8528,6 +9158,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8577,6 +9212,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8603,6 +9239,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8629,6 +9266,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8638,8 +9276,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_884
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_884::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8677,12 +9323,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8847,6 +9502,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9056,17 +9712,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9088,6 +9757,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9100,6 +9770,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9172,6 +9843,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9183,6 +9856,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9238,6 +9913,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9249,6 +9926,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9262,6 +9941,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9274,6 +9955,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9285,6 +9968,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9312,6 +9997,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9321,6 +10008,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9329,6 +10021,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9339,6 +10033,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9350,6 +10049,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_1270
+
+honor the ABI compat
+"""
 struct __JL_Ctag_1270
     data::NTuple{4, UInt8}
 end
@@ -9371,6 +10075,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1270}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{36, UInt8}
 end
@@ -9397,6 +10106,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9420,6 +10134,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9461,6 +10177,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9556,6 +10273,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9583,6 +10305,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9590,8 +10317,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9615,6 +10350,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9787,6 +10523,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9863,6 +10602,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10073,6 +10815,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10286,10 +11029,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_1118
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_1118::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10297,6 +11050,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10309,6 +11063,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10321,6 +11076,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10333,6 +11089,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10342,8 +11099,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10361,6 +11126,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10413,6 +11183,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10425,6 +11197,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10436,6 +11210,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10653,14 +11429,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10673,6 +11463,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10685,6 +11476,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -10697,6 +11489,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10706,6 +11499,11 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+    __JL_Ctag_1225
+
+Documentation not found
+"""
 struct __JL_Ctag_1225
     __lock::Cint
     __nr_readers::Cuint
@@ -10746,6 +11544,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1225}, f::Symbol, v)
 end
 
 
+"""
+    __pthread_mutex_s
+
+Documentation not found
+"""
 struct __pthread_mutex_s
     data::NTuple{24, UInt8}
 end
@@ -10772,6 +11575,11 @@ function Base.setproperty!(x::Ptr{__pthread_mutex_s}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __JL_Ctag_1226
+
+Documentation not found
+"""
 struct __JL_Ctag_1226
     __lock::Cint
     __futex::Cuint
@@ -10806,6 +11614,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1226}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1308
+
+Documentation not found
+"""
 struct __JL_Ctag_1308
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10828,6 +11641,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1308}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1309
+
+Documentation not found
+"""
 struct __JL_Ctag_1309
     si_tid::Cint
     si_overrun::Cint
@@ -10852,6 +11670,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1309}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1310
+
+Documentation not found
+"""
 struct __JL_Ctag_1310
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10876,6 +11699,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1310}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1311
+
+Documentation not found
+"""
 struct __JL_Ctag_1311
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10904,6 +11732,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1311}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1312
+
+Documentation not found
+"""
 struct __JL_Ctag_1312
     si_addr::Ptr{Cvoid}
 end
@@ -10924,6 +11757,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1312}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1313
+
+Documentation not found
+"""
 struct __JL_Ctag_1313
     si_band::Clong
     si_fd::Cint
@@ -10946,38 +11784,86 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1313}, f::Symbol, v)
 end
 
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10986,18 +11872,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 32
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -11008,15 +11915,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,53 +1,53 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const __uid_t = Cuint
 
 """
-Documentation not found
+Documentation not found.
 """
 const __pid_t = Cint
 
 """
-Documentation not found
+Documentation not found.
 """
 const __clock_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const __time_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = __time_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = Culong
 
 """
     __pthread_internal_slist
 
-Documentation not found
+Documentation not found.
 """
 struct __pthread_internal_slist
     __next::Ptr{__pthread_internal_slist}
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const __pthread_slist_t = __pthread_internal_slist
 
 """
     pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_mutex_t
     data::NTuple{24, UInt8}
@@ -74,14 +74,14 @@ end
 """
     pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_cond_t
     data::NTuple{48, UInt8}
 end
 
 function Base.getproperty(x::Ptr{pthread_cond_t}, f::Symbol)
-    f === :__data && return Ptr{__JL_Ctag_1226}(x + 0)
+    f === :__data && return Ptr{__JL_Ctag_1181}(x + 0)
     f === :__size && return Ptr{NTuple{48, Cchar}}(x + 0)
     f === :__align && return Ptr{Clonglong}(x + 0)
     return getfield(x, f)
@@ -99,21 +99,21 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = Cint
 
 """
     pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_rwlock_t
     data::NTuple{32, UInt8}
 end
 
 function Base.getproperty(x::Ptr{pthread_rwlock_t}, f::Symbol)
-    f === :__data && return Ptr{__JL_Ctag_1225}(x + 0)
+    f === :__data && return Ptr{__JL_Ctag_1182}(x + 0)
     f === :__size && return Ptr{NTuple{32, Cchar}}(x + 0)
     f === :__align && return Ptr{Clong}(x + 0)
     return getfield(x, f)
@@ -133,7 +133,7 @@ end
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -152,7 +152,7 @@ end
 """
     sigval
 
-Documentation not found
+Documentation not found.
 """
 struct sigval
     data::NTuple{4, UInt8}
@@ -176,73 +176,74 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const sigval_t = sigval
 
 """
-    __JL_Ctag_1307
-
-Documentation not found
+Documentation not found.
 """
-struct __JL_Ctag_1307
+const __sigchld_clock_t = __clock_t
+
+"""
+    __JL_Ctag_1235
+
+Documentation not found.
+"""
+struct __JL_Ctag_1235
     data::NTuple{116, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_1307}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_1235}, f::Symbol)
     f === :_pad && return Ptr{NTuple{29, Cint}}(x + 0)
-    f === :_kill && return Ptr{__JL_Ctag_1308}(x + 0)
-    f === :_timer && return Ptr{__JL_Ctag_1309}(x + 0)
-    f === :_rt && return Ptr{__JL_Ctag_1310}(x + 0)
-    f === :_sigchld && return Ptr{__JL_Ctag_1311}(x + 0)
-    f === :_sigfault && return Ptr{__JL_Ctag_1312}(x + 0)
-    f === :_sigpoll && return Ptr{__JL_Ctag_1313}(x + 0)
+    f === :_kill && return Ptr{__JL_Ctag_1236}(x + 0)
+    f === :_timer && return Ptr{__JL_Ctag_1237}(x + 0)
+    f === :_rt && return Ptr{__JL_Ctag_1238}(x + 0)
+    f === :_sigchld && return Ptr{__JL_Ctag_1239}(x + 0)
+    f === :_sigfault && return Ptr{__JL_Ctag_1240}(x + 0)
+    f === :_sigpoll && return Ptr{__JL_Ctag_1241}(x + 0)
+    f === :_sigsys && return Ptr{__JL_Ctag_1242}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_1307, f::Symbol)
-    r = Ref{__JL_Ctag_1307}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1307}, r)
+function Base.getproperty(x::__JL_Ctag_1235, f::Symbol)
+    r = Ref{__JL_Ctag_1235}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1235}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_1307}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_1235}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
 """
-    siginfo
+    siginfo_t
 
-Documentation not found
+Documentation not found.
 """
-struct siginfo
+struct siginfo_t
     data::NTuple{128, UInt8}
 end
 
-function Base.getproperty(x::Ptr{siginfo}, f::Symbol)
+function Base.getproperty(x::Ptr{siginfo_t}, f::Symbol)
     f === :si_signo && return Ptr{Cint}(x + 0)
     f === :si_errno && return Ptr{Cint}(x + 4)
     f === :si_code && return Ptr{Cint}(x + 8)
-    f === :_sifields && return Ptr{__JL_Ctag_1307}(x + 12)
+    f === :_sifields && return Ptr{__JL_Ctag_1235}(x + 12)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::siginfo, f::Symbol)
-    r = Ref{siginfo}(x)
-    ptr = Base.unsafe_convert(Ptr{siginfo}, r)
+function Base.getproperty(x::siginfo_t, f::Symbol)
+    r = Ref{siginfo_t}(x)
+    ptr = Base.unsafe_convert(Ptr{siginfo_t}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{siginfo}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{siginfo_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
-
-"""
-Documentation not found
-"""
-const siginfo_t = siginfo
 
 """
     aws_allocator
@@ -274,7 +275,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -678,7 +679,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -691,7 +692,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -704,7 +705,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -717,7 +718,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -744,7 +745,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -757,7 +758,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -770,7 +771,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -783,7 +784,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -964,7 +965,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -977,7 +978,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -990,7 +991,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -1003,7 +1004,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -1016,7 +1017,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -1029,7 +1030,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -1042,7 +1043,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1055,7 +1056,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1068,7 +1069,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1081,7 +1082,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1094,7 +1095,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1107,7 +1108,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1120,7 +1121,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1133,7 +1134,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1146,7 +1147,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1159,7 +1160,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1172,7 +1173,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1185,7 +1186,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1198,7 +1199,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1211,7 +1212,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1224,7 +1225,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1237,7 +1238,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1250,7 +1251,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1263,7 +1264,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1274,18 +1275,18 @@ function aws_max_double(a, b)
 end
 
 """
-    __JL_Ctag_41
+    __JL_Ctag_39
 
-Documentation not found
+Documentation not found.
 """
-@cenum __JL_Ctag_41::UInt32 begin
+@cenum __JL_Ctag_39::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1674,7 +1675,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1685,7 +1686,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2126,7 +2127,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2383,7 +2384,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2480,7 +2481,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3107,7 +3108,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3120,7 +3121,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3133,7 +3134,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3146,7 +3147,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3159,7 +3160,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3690,7 +3691,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3714,7 +3715,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -4034,7 +4035,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4079,7 +4080,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4110,7 +4111,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4171,7 +4172,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4184,7 +4185,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4197,7 +4198,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4210,7 +4211,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4309,7 +4310,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4377,7 +4378,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4454,13 +4455,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4502,7 +4503,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4514,14 +4515,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4587,7 +4588,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4653,7 +4654,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4682,7 +4683,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4717,11 +4718,11 @@ function aws_cross_process_lock_release(instance_lock)
 end
 
 """
-    __JL_Ctag_292
+    __JL_Ctag_280
 
-Documentation not found
+Documentation not found.
 """
-@cenum __JL_Ctag_292::UInt32 begin
+@cenum __JL_Ctag_280::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
@@ -4729,7 +4730,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4741,7 +4742,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4761,7 +4762,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4776,7 +4777,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4924,7 +4925,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4937,7 +4938,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4950,7 +4951,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4963,7 +4964,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4976,7 +4977,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4989,7 +4990,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -5002,7 +5003,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -5015,7 +5016,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -5028,7 +5029,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -5041,7 +5042,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5054,7 +5055,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5403,7 +5404,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5444,7 +5445,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5456,10 +5457,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5471,7 +5472,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5482,7 +5483,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5497,7 +5498,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5510,7 +5511,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5553,7 +5554,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5606,7 +5607,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5619,7 +5620,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5628,7 +5629,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5789,7 +5790,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5830,7 +5831,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5927,14 +5928,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5945,7 +5946,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6185,7 +6186,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6261,11 +6262,11 @@ function aws_file_get_length(file, length)
 end
 
 """
-    __JL_Ctag_443
+    __JL_Ctag_424
 
-Documentation not found
+Documentation not found.
 """
-@cenum __JL_Ctag_443::UInt32 begin
+@cenum __JL_Ctag_424::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
     AWS_COMMON_HASH_TABLE_ITER_ERROR = 4
@@ -6286,7 +6287,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6297,7 +6298,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6423,7 +6424,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6441,7 +6442,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6653,7 +6654,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6748,7 +6749,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6759,10 +6760,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6780,10 +6781,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6801,9 +6802,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6821,10 +6822,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6842,9 +6843,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6862,9 +6863,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6880,10 +6881,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6899,10 +6900,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6918,10 +6919,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6939,11 +6940,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6959,10 +6960,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6978,10 +6979,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6997,10 +6998,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -7022,11 +7023,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -7044,10 +7045,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7063,10 +7064,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7082,9 +7083,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7100,10 +7101,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7125,11 +7126,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7145,11 +7146,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7165,9 +7166,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7183,9 +7184,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7201,9 +7202,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7219,9 +7220,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7237,9 +7238,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7255,9 +7256,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7273,9 +7274,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7293,7 +7294,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7313,10 +7314,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7336,10 +7337,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7355,10 +7356,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7532,7 +7533,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7615,20 +7616,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7637,20 +7638,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7732,20 +7733,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7768,7 +7769,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7795,7 +7796,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7841,7 +7842,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7937,7 +7938,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7971,18 +7972,18 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 const aws_log_subject_t = UInt32
 
 """
-    __JL_Ctag_660
+    __JL_Ctag_636
 
 Each library gets space for 2^^10 log subject entries
 """
-@cenum __JL_Ctag_660::UInt32 begin
+@cenum __JL_Ctag_636::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7993,7 +7994,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -8003,7 +8004,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8063,10 +8064,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8096,10 +8097,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8141,7 +8142,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8286,26 +8287,26 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
-    __JL_Ctag_681
+    __JL_Ctag_656
 
-Documentation not found
+Documentation not found.
 """
-@cenum __JL_Ctag_681::UInt32 begin
+@cenum __JL_Ctag_656::UInt32 begin
     AWS_CACHE_LINE = 64
 end
 
@@ -8388,7 +8389,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8399,7 +8400,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8628,7 +8629,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8644,9 +8645,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8660,7 +8661,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8671,7 +8672,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8682,7 +8683,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8740,7 +8741,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8753,7 +8754,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8938,7 +8939,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8956,7 +8957,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8968,7 +8969,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8986,9 +8987,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -9004,9 +9005,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9161,7 +9162,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9212,7 +9213,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9239,7 +9240,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9266,7 +9267,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9277,16 +9278,16 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
 """
-    __JL_Ctag_884
+    __JL_Ctag_852
 
 Each library gets space for 2^^8 category entries
 """
-@cenum __JL_Ctag_884::UInt32 begin
+@cenum __JL_Ctag_852::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
 
@@ -9411,7 +9412,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9502,7 +9505,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9613,7 +9616,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9715,7 +9718,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9726,7 +9729,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9734,7 +9737,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9757,7 +9760,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9770,7 +9773,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -10011,7 +10014,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -10036,7 +10039,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10050,28 +10053,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    __JL_Ctag_1270
+    __JL_Ctag_1219
 
 honor the ABI compat
 """
-struct __JL_Ctag_1270
+struct __JL_Ctag_1219
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_1270}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_1219}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_1270, f::Symbol)
-    r = Ref{__JL_Ctag_1270}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1270}, r)
+function Base.getproperty(x::__JL_Ctag_1219, f::Symbol)
+    r = Ref{__JL_Ctag_1219}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1219}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_1270}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_1219}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10091,7 +10094,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{__JL_Ctag_1270}(x + 32)
+    f === :abi_extension && return Ptr{__JL_Ctag_1219}(x + 32)
     return getfield(x, f)
 end
 
@@ -10109,7 +10112,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10177,7 +10180,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10276,7 +10279,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10308,7 +10311,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10318,14 +10321,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10350,7 +10353,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10524,7 +10527,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10603,7 +10606,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10815,7 +10818,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -11032,25 +11035,25 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
 """
-    __JL_Ctag_1118
+    __JL_Ctag_1077
 
 36 bytes for the UUID plus one more for the null terminator.
 """
-@cenum __JL_Ctag_1118::UInt32 begin
+@cenum __JL_Ctag_1077::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
 
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11063,7 +11066,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11076,7 +11079,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11089,7 +11092,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11100,14 +11103,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11129,7 +11132,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11430,26 +11433,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11463,7 +11466,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11476,7 +11479,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -11489,7 +11492,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11500,11 +11503,50 @@ function enable_vt_mode()
 end
 
 """
-    __JL_Ctag_1225
+    __JL_Ctag_1181
 
-Documentation not found
+Documentation not found.
 """
-struct __JL_Ctag_1225
+struct __JL_Ctag_1181
+    __lock::Cint
+    __futex::Cuint
+    __total_seq::Culonglong
+    __wakeup_seq::Culonglong
+    __woken_seq::Culonglong
+    __mutex::Ptr{Cvoid}
+    __nwaiters::Cuint
+    __broadcast_seq::Cuint
+end
+function Base.getproperty(x::Ptr{__JL_Ctag_1181}, f::Symbol)
+    f === :__lock && return Ptr{Cint}(x + 0)
+    f === :__futex && return Ptr{Cuint}(x + 4)
+    f === :__total_seq && return Ptr{Culonglong}(x + 8)
+    f === :__wakeup_seq && return Ptr{Culonglong}(x + 16)
+    f === :__woken_seq && return Ptr{Culonglong}(x + 24)
+    f === :__mutex && return Ptr{Ptr{Cvoid}}(x + 32)
+    f === :__nwaiters && return Ptr{Cuint}(x + 36)
+    f === :__broadcast_seq && return Ptr{Cuint}(x + 40)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_1181, f::Symbol)
+    r = Ref{__JL_Ctag_1181}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1181}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_1181}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+
+"""
+    __JL_Ctag_1182
+
+Documentation not found.
+"""
+struct __JL_Ctag_1182
     __lock::Cint
     __nr_readers::Cuint
     __readers_wakeup::Cuint
@@ -11517,7 +11559,7 @@ struct __JL_Ctag_1225
     __pad2::Cuchar
     __writer::Cint
 end
-function Base.getproperty(x::Ptr{__JL_Ctag_1225}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_1182}, f::Symbol)
     f === :__lock && return Ptr{Cint}(x + 0)
     f === :__nr_readers && return Ptr{Cuint}(x + 4)
     f === :__readers_wakeup && return Ptr{Cuint}(x + 8)
@@ -11532,14 +11574,14 @@ function Base.getproperty(x::Ptr{__JL_Ctag_1225}, f::Symbol)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_1225, f::Symbol)
-    r = Ref{__JL_Ctag_1225}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1225}, r)
+function Base.getproperty(x::__JL_Ctag_1182, f::Symbol)
+    r = Ref{__JL_Ctag_1182}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1182}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_1225}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_1182}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -11547,7 +11589,7 @@ end
 """
     __pthread_mutex_s
 
-Documentation not found
+Documentation not found.
 """
 struct __pthread_mutex_s
     data::NTuple{24, UInt8}
@@ -11576,293 +11618,283 @@ function Base.setproperty!(x::Ptr{__pthread_mutex_s}, f::Symbol, v)
 end
 
 """
-    __JL_Ctag_1226
+    __JL_Ctag_1236
 
-Documentation not found
+Documentation not found.
 """
-struct __JL_Ctag_1226
-    __lock::Cint
-    __futex::Cuint
-    __total_seq::Culonglong
-    __wakeup_seq::Culonglong
-    __woken_seq::Culonglong
-    __mutex::Ptr{Cvoid}
-    __nwaiters::Cuint
-    __broadcast_seq::Cuint
-end
-function Base.getproperty(x::Ptr{__JL_Ctag_1226}, f::Symbol)
-    f === :__lock && return Ptr{Cint}(x + 0)
-    f === :__futex && return Ptr{Cuint}(x + 4)
-    f === :__total_seq && return Ptr{Culonglong}(x + 8)
-    f === :__wakeup_seq && return Ptr{Culonglong}(x + 16)
-    f === :__woken_seq && return Ptr{Culonglong}(x + 24)
-    f === :__mutex && return Ptr{Ptr{Cvoid}}(x + 32)
-    f === :__nwaiters && return Ptr{Cuint}(x + 36)
-    f === :__broadcast_seq && return Ptr{Cuint}(x + 40)
-    return getfield(x, f)
-end
-
-function Base.getproperty(x::__JL_Ctag_1226, f::Symbol)
-    r = Ref{__JL_Ctag_1226}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1226}, r)
-    fptr = getproperty(ptr, f)
-    GC.@preserve r unsafe_load(fptr)
-end
-
-function Base.setproperty!(x::Ptr{__JL_Ctag_1226}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
-end
-
-
-"""
-    __JL_Ctag_1308
-
-Documentation not found
-"""
-struct __JL_Ctag_1308
+struct __JL_Ctag_1236
     si_pid::__pid_t
     si_uid::__uid_t
 end
-function Base.getproperty(x::Ptr{__JL_Ctag_1308}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_1236}, f::Symbol)
     f === :si_pid && return Ptr{__pid_t}(x + 0)
     f === :si_uid && return Ptr{__uid_t}(x + 4)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_1308, f::Symbol)
-    r = Ref{__JL_Ctag_1308}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1308}, r)
+function Base.getproperty(x::__JL_Ctag_1236, f::Symbol)
+    r = Ref{__JL_Ctag_1236}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1236}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_1308}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_1236}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
 
 """
-    __JL_Ctag_1309
+    __JL_Ctag_1237
 
-Documentation not found
+Documentation not found.
 """
-struct __JL_Ctag_1309
+struct __JL_Ctag_1237
     si_tid::Cint
     si_overrun::Cint
     si_sigval::sigval_t
 end
-function Base.getproperty(x::Ptr{__JL_Ctag_1309}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_1237}, f::Symbol)
     f === :si_tid && return Ptr{Cint}(x + 0)
     f === :si_overrun && return Ptr{Cint}(x + 4)
     f === :si_sigval && return Ptr{sigval_t}(x + 8)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_1309, f::Symbol)
-    r = Ref{__JL_Ctag_1309}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1309}, r)
+function Base.getproperty(x::__JL_Ctag_1237, f::Symbol)
+    r = Ref{__JL_Ctag_1237}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1237}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_1309}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_1237}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
 
 """
-    __JL_Ctag_1310
+    __JL_Ctag_1238
 
-Documentation not found
+Documentation not found.
 """
-struct __JL_Ctag_1310
+struct __JL_Ctag_1238
     si_pid::__pid_t
     si_uid::__uid_t
     si_sigval::sigval_t
 end
-function Base.getproperty(x::Ptr{__JL_Ctag_1310}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_1238}, f::Symbol)
     f === :si_pid && return Ptr{__pid_t}(x + 0)
     f === :si_uid && return Ptr{__uid_t}(x + 4)
     f === :si_sigval && return Ptr{sigval_t}(x + 8)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_1310, f::Symbol)
-    r = Ref{__JL_Ctag_1310}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1310}, r)
+function Base.getproperty(x::__JL_Ctag_1238, f::Symbol)
+    r = Ref{__JL_Ctag_1238}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1238}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_1310}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_1238}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
 
 """
-    __JL_Ctag_1311
+    __JL_Ctag_1239
 
-Documentation not found
+Documentation not found.
 """
-struct __JL_Ctag_1311
+struct __JL_Ctag_1239
     si_pid::__pid_t
     si_uid::__uid_t
     si_status::Cint
-    si_utime::__clock_t
-    si_stime::__clock_t
+    si_utime::__sigchld_clock_t
+    si_stime::__sigchld_clock_t
 end
-function Base.getproperty(x::Ptr{__JL_Ctag_1311}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_1239}, f::Symbol)
     f === :si_pid && return Ptr{__pid_t}(x + 0)
     f === :si_uid && return Ptr{__uid_t}(x + 4)
     f === :si_status && return Ptr{Cint}(x + 8)
-    f === :si_utime && return Ptr{__clock_t}(x + 12)
-    f === :si_stime && return Ptr{__clock_t}(x + 16)
+    f === :si_utime && return Ptr{__sigchld_clock_t}(x + 12)
+    f === :si_stime && return Ptr{__sigchld_clock_t}(x + 16)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_1311, f::Symbol)
-    r = Ref{__JL_Ctag_1311}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1311}, r)
+function Base.getproperty(x::__JL_Ctag_1239, f::Symbol)
+    r = Ref{__JL_Ctag_1239}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1239}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_1311}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_1239}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
 
 """
-    __JL_Ctag_1312
+    __JL_Ctag_1240
 
-Documentation not found
+Documentation not found.
 """
-struct __JL_Ctag_1312
+struct __JL_Ctag_1240
     si_addr::Ptr{Cvoid}
 end
-function Base.getproperty(x::Ptr{__JL_Ctag_1312}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_1240}, f::Symbol)
     f === :si_addr && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_1312, f::Symbol)
-    r = Ref{__JL_Ctag_1312}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1312}, r)
+function Base.getproperty(x::__JL_Ctag_1240, f::Symbol)
+    r = Ref{__JL_Ctag_1240}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1240}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_1312}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_1240}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
 
 """
-    __JL_Ctag_1313
+    __JL_Ctag_1241
 
-Documentation not found
+Documentation not found.
 """
-struct __JL_Ctag_1313
+struct __JL_Ctag_1241
     si_band::Clong
     si_fd::Cint
 end
-function Base.getproperty(x::Ptr{__JL_Ctag_1313}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_1241}, f::Symbol)
     f === :si_band && return Ptr{Clong}(x + 0)
     f === :si_fd && return Ptr{Cint}(x + 4)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_1313, f::Symbol)
-    r = Ref{__JL_Ctag_1313}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1313}, r)
+function Base.getproperty(x::__JL_Ctag_1241, f::Symbol)
+    r = Ref{__JL_Ctag_1241}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1241}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_1313}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_1241}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
 
 """
-Documentation not found
+    __JL_Ctag_1242
+
+Documentation not found.
+"""
+struct __JL_Ctag_1242
+    _call_addr::Ptr{Cvoid}
+    _syscall::Cint
+    _arch::Cuint
+end
+function Base.getproperty(x::Ptr{__JL_Ctag_1242}, f::Symbol)
+    f === :_call_addr && return Ptr{Ptr{Cvoid}}(x + 0)
+    f === :_syscall && return Ptr{Cint}(x + 4)
+    f === :_arch && return Ptr{Cuint}(x + 8)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_1242, f::Symbol)
+    r = Ref{__JL_Ctag_1242}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_1242}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_1242}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+
+"""
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11873,37 +11905,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 32
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11916,32 +11948,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,14 +1,14 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = Clong
 
 """
     __JL_Ctag_328
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_328
     data::NTuple{24, UInt8}
@@ -35,7 +35,7 @@ end
 """
     pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_mutex_t
     data::NTuple{24, UInt8}
@@ -60,7 +60,7 @@ end
 """
     __JL_Ctag_324
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_324
     data::NTuple{48, UInt8}
@@ -87,7 +87,7 @@ end
 """
     pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_cond_t
     data::NTuple{48, UInt8}
@@ -112,7 +112,7 @@ end
 """
     __JL_Ctag_331
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_331
     data::NTuple{32, UInt8}
@@ -139,7 +139,7 @@ end
 """
     pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_rwlock_t
     data::NTuple{32, UInt8}
@@ -162,24 +162,24 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct __pthread end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = Ptr{__pthread}
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = Cint
 
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -225,7 +225,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -629,7 +629,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -642,7 +642,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -655,7 +655,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -668,7 +668,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -695,7 +695,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -708,7 +708,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -721,7 +721,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -734,7 +734,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -915,7 +915,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -928,7 +928,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -941,7 +941,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -954,7 +954,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -967,7 +967,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -980,7 +980,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -993,7 +993,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1006,7 +1006,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1019,7 +1019,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1032,7 +1032,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1045,7 +1045,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1058,7 +1058,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1071,7 +1071,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1084,7 +1084,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1097,7 +1097,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1110,7 +1110,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1123,7 +1123,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1136,7 +1136,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1149,7 +1149,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1162,7 +1162,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1175,7 +1175,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1188,7 +1188,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1201,7 +1201,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1214,7 +1214,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1227,7 +1227,7 @@ end
 """
     __JL_Ctag_9
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_9::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1236,7 +1236,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1625,7 +1625,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1636,7 +1636,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2077,7 +2077,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2334,7 +2334,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2431,7 +2431,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3058,7 +3058,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3071,7 +3071,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3084,7 +3084,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3097,7 +3097,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3110,7 +3110,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3641,7 +3641,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3665,7 +3665,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -3985,7 +3985,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4030,7 +4030,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4061,7 +4061,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4122,7 +4122,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4135,7 +4135,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4148,7 +4148,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4161,7 +4161,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4260,7 +4260,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4328,7 +4328,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4405,13 +4405,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4453,7 +4453,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4465,14 +4465,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4538,7 +4538,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4604,7 +4604,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4633,7 +4633,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4670,7 +4670,7 @@ end
 """
     __JL_Ctag_66
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_66::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4680,7 +4680,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4692,7 +4692,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4712,7 +4712,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4727,7 +4727,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4875,7 +4875,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4888,7 +4888,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4901,7 +4901,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4914,7 +4914,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4927,7 +4927,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4940,7 +4940,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4953,7 +4953,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4966,7 +4966,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4979,7 +4979,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4992,7 +4992,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5005,7 +5005,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5354,7 +5354,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5395,7 +5395,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5407,10 +5407,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5422,7 +5422,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5433,7 +5433,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5448,7 +5448,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5461,7 +5461,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5504,7 +5504,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5557,7 +5557,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5570,7 +5570,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5579,7 +5579,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5740,7 +5740,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5781,7 +5781,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5878,14 +5878,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5896,7 +5896,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6136,7 +6136,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6214,7 +6214,7 @@ end
 """
     __JL_Ctag_97
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_97::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6237,7 +6237,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6248,7 +6248,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6374,7 +6374,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6392,7 +6392,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6604,7 +6604,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6699,7 +6699,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6710,10 +6710,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6731,10 +6731,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6752,9 +6752,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6772,10 +6772,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6793,9 +6793,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6813,9 +6813,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6831,10 +6831,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6850,10 +6850,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6869,10 +6869,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6890,11 +6890,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6910,10 +6910,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6929,10 +6929,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6948,10 +6948,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -6973,11 +6973,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -6995,10 +6995,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7014,10 +7014,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7033,9 +7033,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7051,10 +7051,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7076,11 +7076,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7096,11 +7096,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7116,9 +7116,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7134,9 +7134,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7152,9 +7152,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7170,9 +7170,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7188,9 +7188,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7206,9 +7206,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7224,9 +7224,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7244,7 +7244,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7264,10 +7264,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7287,10 +7287,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7306,10 +7306,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7483,7 +7483,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7566,20 +7566,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7588,20 +7588,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7683,20 +7683,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7719,7 +7719,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7746,7 +7746,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7792,7 +7792,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7888,7 +7888,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7933,7 +7933,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7944,7 +7944,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -7954,7 +7954,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8014,10 +8014,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8047,10 +8047,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8092,7 +8092,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8237,24 +8237,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_166
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_166::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8339,7 +8339,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8350,7 +8350,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8579,7 +8579,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8595,9 +8595,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8611,7 +8611,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8622,7 +8622,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8633,7 +8633,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8691,7 +8691,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8704,7 +8704,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8889,7 +8889,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8907,7 +8907,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8919,7 +8919,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8937,9 +8937,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -8955,9 +8955,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9112,7 +9112,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9163,7 +9163,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9190,7 +9190,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9217,7 +9217,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9228,7 +9228,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9362,7 +9362,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9453,7 +9455,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9564,7 +9566,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9666,7 +9668,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9677,7 +9679,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9685,7 +9687,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9708,7 +9710,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9721,7 +9723,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9962,7 +9964,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -9987,7 +9989,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10060,7 +10062,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10128,7 +10130,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10227,7 +10229,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10259,7 +10261,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10269,14 +10271,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10301,7 +10303,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10475,7 +10477,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10554,7 +10556,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10766,7 +10768,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10983,7 +10985,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11001,7 +11003,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11014,7 +11016,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11027,7 +11029,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11040,7 +11042,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11051,14 +11053,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11080,7 +11082,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11381,26 +11383,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11414,7 +11416,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11427,7 +11429,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11438,84 +11440,84 @@ function enable_vt_mode()
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11526,37 +11528,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 32
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11569,32 +11571,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,7 +1,15 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const time_t = Clong
 
+"""
+    __JL_Ctag_328
+
+Documentation not found
+"""
 struct __JL_Ctag_328
     data::NTuple{24, UInt8}
 end
@@ -24,6 +32,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_328}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_mutex_t
+
+Documentation not found
+"""
 struct pthread_mutex_t
     data::NTuple{24, UInt8}
 end
@@ -44,6 +57,11 @@ function Base.setproperty!(x::Ptr{pthread_mutex_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __JL_Ctag_324
+
+Documentation not found
+"""
 struct __JL_Ctag_324
     data::NTuple{48, UInt8}
 end
@@ -66,6 +84,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_324}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_cond_t
+
+Documentation not found
+"""
 struct pthread_cond_t
     data::NTuple{48, UInt8}
 end
@@ -86,6 +109,11 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __JL_Ctag_331
+
+Documentation not found
+"""
 struct __JL_Ctag_331
     data::NTuple{32, UInt8}
 end
@@ -108,6 +136,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_331}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_rwlock_t
+
+Documentation not found
+"""
 struct pthread_rwlock_t
     data::NTuple{32, UInt8}
 end
@@ -128,12 +161,26 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 mutable struct __pthread end
 
+"""
+Documentation not found
+"""
 const pthread_t = Ptr{__pthread}
 
+"""
+Documentation not found
+"""
 const pthread_once_t = Cint
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -148,6 +195,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -173,6 +225,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -184,6 +237,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -252,6 +307,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -260,6 +320,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -273,6 +335,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -284,6 +348,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -297,6 +363,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -308,6 +376,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -321,6 +391,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -332,6 +404,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -345,6 +419,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -356,6 +432,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -369,6 +447,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -381,6 +461,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -392,6 +474,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -545,6 +629,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -557,6 +642,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -569,6 +655,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -581,6 +668,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -607,6 +695,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -619,6 +708,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -631,6 +721,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -643,6 +734,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -823,6 +915,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -835,6 +928,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -847,6 +941,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -859,6 +954,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -871,6 +967,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -883,6 +980,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -895,6 +993,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -907,6 +1006,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -919,6 +1019,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -931,6 +1032,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -943,6 +1045,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -955,6 +1058,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -967,6 +1071,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -979,6 +1084,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -991,6 +1097,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1003,6 +1110,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1015,6 +1123,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1027,6 +1136,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1039,6 +1149,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1051,6 +1162,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1063,6 +1175,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1075,6 +1188,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1087,6 +1201,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1099,6 +1214,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1108,10 +1224,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_9
+
+Documentation not found
+"""
 @cenum __JL_Ctag_9::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1499,6 +1625,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1508,6 +1635,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1519,6 +1649,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1940,6 +2077,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2196,6 +2334,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2292,6 +2431,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2918,6 +3058,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2930,6 +3071,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2942,6 +3084,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2954,6 +3097,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2966,6 +3110,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3493,6 +3638,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3512,6 +3662,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3830,6 +3985,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3871,6 +4027,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3897,6 +4058,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3942,6 +4108,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3954,6 +4122,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3966,6 +4135,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -3978,6 +4148,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -3990,6 +4161,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4085,6 +4257,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4148,6 +4325,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4170,6 +4352,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4264,6 +4453,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4274,8 +4464,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4337,6 +4535,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4398,6 +4601,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4424,6 +4632,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4456,11 +4667,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_66
+
+Documentation not found
+"""
 @cenum __JL_Ctag_66::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4468,6 +4689,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4483,6 +4709,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4493,6 +4724,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4639,6 +4875,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4651,6 +4888,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4663,6 +4901,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4675,6 +4914,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4687,6 +4927,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4699,6 +4940,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4711,6 +4953,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4723,6 +4966,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4735,6 +4979,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4747,6 +4992,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4759,6 +5005,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4869,6 +5116,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4880,6 +5129,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4893,6 +5144,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4904,6 +5157,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4917,6 +5172,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4928,6 +5185,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4941,6 +5200,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4952,6 +5213,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4965,6 +5228,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4976,6 +5241,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -4989,6 +5256,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5000,6 +5269,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5013,6 +5284,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5024,6 +5297,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5037,6 +5312,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5048,6 +5325,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5061,6 +5340,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5070,6 +5351,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5080,6 +5366,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5093,6 +5381,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5102,6 +5392,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5126,6 +5421,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5150,6 +5448,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5162,6 +5461,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5201,6 +5501,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5209,6 +5514,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5222,6 +5529,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5234,6 +5543,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5243,6 +5554,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5251,16 +5567,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5274,6 +5600,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5285,6 +5613,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5298,6 +5628,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5309,6 +5641,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5322,6 +5656,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5333,6 +5669,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5346,6 +5684,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5358,6 +5698,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5369,6 +5711,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5396,6 +5740,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5433,6 +5778,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5527,14 +5877,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5815,6 +6178,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5827,6 +6198,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5836,6 +6211,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_97
+
+Documentation not found
+"""
 @cenum __JL_Ctag_97::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5854,12 +6234,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6214,6 +6604,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6307,6 +6698,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7171,33 +7565,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7207,6 +7637,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7220,6 +7654,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7232,6 +7670,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7242,22 +7682,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7280,6 +7743,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7294,6 +7762,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7306,6 +7778,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7315,6 +7789,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7322,6 +7801,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7335,6 +7816,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7347,6 +7830,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7358,6 +7843,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7398,6 +7885,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7429,21 +7921,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_161
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_161::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7457,6 +7969,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7572,6 +8091,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7633,6 +8155,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7645,6 +8169,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7656,6 +8182,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7708,12 +8236,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_166
+
+Documentation not found
+"""
 @cenum __JL_Ctag_166::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7789,14 +8331,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8053,12 +8608,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8126,6 +8691,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8138,6 +8704,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8161,10 +8728,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8178,6 +8750,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8189,6 +8763,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8202,6 +8778,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8213,6 +8791,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8226,6 +8806,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8237,6 +8819,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8250,6 +8834,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8261,6 +8847,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8274,6 +8862,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8286,6 +8876,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8296,14 +8888,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8394,6 +8999,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8502,6 +9109,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8551,6 +9163,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8577,6 +9190,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8603,6 +9217,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8612,8 +9227,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_221
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_221::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8651,12 +9274,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8821,6 +9453,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9030,17 +9663,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9062,6 +9708,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9074,6 +9721,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9146,6 +9794,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9157,6 +9807,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9212,6 +9864,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9223,6 +9877,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9236,6 +9892,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9248,6 +9906,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9259,6 +9919,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9286,6 +9948,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9295,6 +9959,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9303,6 +9972,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9313,6 +9984,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9324,6 +10000,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_320
+
+honor the ABI compat
+"""
 struct __JL_Ctag_320
     data::NTuple{4, UInt8}
 end
@@ -9345,6 +10026,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_320}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{36, UInt8}
 end
@@ -9371,6 +10057,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9394,6 +10085,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9435,6 +10128,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9530,6 +10224,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9557,6 +10256,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9564,8 +10268,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9589,6 +10301,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9761,6 +10474,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9837,6 +10553,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10047,6 +10766,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10260,10 +10980,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_275
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_275::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10271,6 +11001,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10283,6 +11014,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10295,6 +11027,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10307,6 +11040,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10316,8 +11050,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10335,6 +11077,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10387,6 +11134,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10399,6 +11148,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10410,6 +11161,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10627,14 +11380,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10647,6 +11414,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10659,6 +11427,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10668,38 +11437,86 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10708,18 +11525,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 32
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -10730,15 +11568,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,24 +1,55 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const __uid_t = Cuint
 
+"""
+Documentation not found
+"""
 const __pid_t = Cint
 
+"""
+Documentation not found
+"""
 const __clock_t = Clong
 
+"""
+Documentation not found
+"""
 const __time_t = Clong
 
+"""
+Documentation not found
+"""
 const time_t = __time_t
 
+"""
+Documentation not found
+"""
 const pthread_t = Culong
 
+"""
+    __pthread_internal_list
+
+Documentation not found
+"""
 struct __pthread_internal_list
     __prev::Ptr{__pthread_internal_list}
     __next::Ptr{__pthread_internal_list}
 end
 
+"""
+Documentation not found
+"""
 const __pthread_list_t = __pthread_internal_list
 
+"""
+    pthread_mutex_t
+
+Documentation not found
+"""
 struct pthread_mutex_t
     data::NTuple{40, UInt8}
 end
@@ -41,6 +72,11 @@ function Base.setproperty!(x::Ptr{pthread_mutex_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_cond_t
+
+Documentation not found
+"""
 struct pthread_cond_t
     data::NTuple{48, UInt8}
 end
@@ -63,8 +99,16 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const pthread_once_t = Cint
 
+"""
+    pthread_rwlock_t
+
+Documentation not found
+"""
 struct pthread_rwlock_t
     data::NTuple{56, UInt8}
 end
@@ -87,6 +131,11 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -101,6 +150,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    sigval
+
+Documentation not found
+"""
 struct sigval
     data::NTuple{8, UInt8}
 end
@@ -122,8 +176,16 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const sigval_t = sigval
 
+"""
+    __JL_Ctag_1238
+
+Documentation not found
+"""
 struct __JL_Ctag_1238
     data::NTuple{112, UInt8}
 end
@@ -151,6 +213,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1238}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    siginfo_t
+
+Documentation not found
+"""
 struct siginfo_t
     data::NTuple{128, UInt8}
 end
@@ -174,6 +241,11 @@ function Base.setproperty!(x::Ptr{siginfo_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -199,6 +271,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -210,6 +283,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -278,6 +353,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -286,6 +366,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -299,6 +381,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -310,6 +394,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -323,6 +409,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -334,6 +422,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -347,6 +437,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -358,6 +450,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -371,6 +465,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -382,6 +478,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -395,6 +493,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -407,6 +507,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -418,6 +520,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -571,6 +675,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -583,6 +688,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -595,6 +701,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -607,6 +714,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -633,6 +741,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -645,6 +754,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -657,6 +767,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -669,6 +780,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -849,6 +961,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -861,6 +974,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -873,6 +987,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -885,6 +1000,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -897,6 +1013,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -909,6 +1026,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -921,6 +1039,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -933,6 +1052,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -945,6 +1065,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -957,6 +1078,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -969,6 +1091,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -981,6 +1104,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -993,6 +1117,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1005,6 +1130,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1017,6 +1143,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1029,6 +1156,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1041,6 +1169,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1053,6 +1182,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1065,6 +1195,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1077,6 +1208,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1089,6 +1221,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1101,6 +1234,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1113,6 +1247,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1125,6 +1260,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1134,10 +1270,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_39
+
+Documentation not found
+"""
 @cenum __JL_Ctag_39::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1525,6 +1671,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1534,6 +1681,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1545,6 +1695,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1966,6 +2123,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2222,6 +2380,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2318,6 +2477,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2944,6 +3104,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2956,6 +3117,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2968,6 +3130,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2980,6 +3143,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2992,6 +3156,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3519,6 +3684,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3538,6 +3708,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3856,6 +4031,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3897,6 +4073,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3923,6 +4104,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3968,6 +4154,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3980,6 +4168,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3992,6 +4181,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4004,6 +4194,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4016,6 +4207,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4111,6 +4303,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4174,6 +4371,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4196,6 +4398,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4290,6 +4499,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4300,8 +4510,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4363,6 +4581,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4424,6 +4647,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4450,6 +4678,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4482,11 +4713,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_280
+
+Documentation not found
+"""
 @cenum __JL_Ctag_280::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4494,6 +4735,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4509,6 +4755,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4519,6 +4770,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4665,6 +4921,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4677,6 +4934,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4689,6 +4947,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4701,6 +4960,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4713,6 +4973,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4725,6 +4986,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4737,6 +4999,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4749,6 +5012,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4761,6 +5025,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4773,6 +5038,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4785,6 +5051,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4895,6 +5162,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4906,6 +5175,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4919,6 +5190,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4930,6 +5203,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4943,6 +5218,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4954,6 +5231,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4967,6 +5246,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4978,6 +5259,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4991,6 +5274,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -5002,6 +5287,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -5015,6 +5302,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5026,6 +5315,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5039,6 +5330,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5050,6 +5343,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5063,6 +5358,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5074,6 +5371,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5087,6 +5386,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5096,6 +5397,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5106,6 +5412,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5119,6 +5427,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5128,6 +5438,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5152,6 +5467,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5176,6 +5494,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5188,6 +5507,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5227,6 +5547,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5235,6 +5560,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5248,6 +5575,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5260,6 +5589,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5269,6 +5600,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5277,16 +5613,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5300,6 +5646,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5311,6 +5659,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5324,6 +5674,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5335,6 +5687,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5348,6 +5702,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5359,6 +5715,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5372,6 +5730,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5384,6 +5744,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5395,6 +5757,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5422,6 +5786,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5459,6 +5824,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5553,14 +5923,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5841,6 +6224,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5853,6 +6244,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5862,6 +6257,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_424
+
+Documentation not found
+"""
 @cenum __JL_Ctag_424::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5880,12 +6280,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6240,6 +6650,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6333,6 +6744,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7197,33 +7611,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7233,6 +7683,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7246,6 +7700,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7258,6 +7716,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7268,22 +7728,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7306,6 +7789,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7320,6 +7808,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7332,6 +7824,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7341,6 +7835,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7348,6 +7847,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7361,6 +7862,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7373,6 +7876,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7384,6 +7889,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7424,6 +7931,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7455,21 +7967,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_636
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_636::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7483,6 +8015,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7598,6 +8137,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7659,6 +8201,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7671,6 +8215,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7682,6 +8228,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7734,12 +8282,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_656
+
+Documentation not found
+"""
 @cenum __JL_Ctag_656::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7815,14 +8377,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8079,12 +8654,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8152,6 +8737,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8164,6 +8750,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8187,10 +8774,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8204,6 +8796,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8215,6 +8809,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8228,6 +8824,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8239,6 +8837,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8252,6 +8852,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8263,6 +8865,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8276,6 +8880,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8287,6 +8893,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8300,6 +8908,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8312,6 +8922,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8322,14 +8934,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8420,6 +9045,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8528,6 +9155,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8577,6 +9209,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8603,6 +9236,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8629,6 +9263,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8638,8 +9273,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_852
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_852::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8677,12 +9320,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8847,6 +9499,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9056,17 +9709,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9088,6 +9754,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9100,6 +9767,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9172,6 +9840,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9183,6 +9853,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9238,6 +9910,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9249,6 +9923,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9262,6 +9938,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9274,6 +9952,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9285,6 +9965,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9312,6 +9994,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9321,6 +10005,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9329,6 +10018,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9339,6 +10030,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9350,6 +10046,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_1222
+
+honor the ABI compat
+"""
 struct __JL_Ctag_1222
     data::NTuple{8, UInt8}
 end
@@ -9371,6 +10072,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1222}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{64, UInt8}
 end
@@ -9397,6 +10103,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9420,6 +10131,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9461,6 +10174,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9556,6 +10270,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9583,6 +10302,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9590,8 +10314,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9615,6 +10347,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9787,6 +10520,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9863,6 +10599,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10073,6 +10812,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10286,10 +11026,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_1077
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_1077::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10297,6 +11047,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10309,6 +11060,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10321,6 +11073,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10333,6 +11086,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10342,8 +11096,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10361,6 +11123,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10413,6 +11180,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10425,6 +11194,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10436,6 +11207,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10653,14 +11426,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10673,6 +11460,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10685,6 +11473,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -10697,6 +11486,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10706,6 +11496,11 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+    __JL_Ctag_1184
+
+Documentation not found
+"""
 struct __JL_Ctag_1184
     __lock::Cint
     __futex::Cuint
@@ -10740,6 +11535,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1184}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1185
+
+Documentation not found
+"""
 struct __JL_Ctag_1185
     __lock::Cint
     __nr_readers::Cuint
@@ -10780,6 +11580,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1185}, f::Symbol, v)
 end
 
 
+"""
+    __pthread_mutex_s
+
+Documentation not found
+"""
 struct __pthread_mutex_s
     __lock::Cint
     __count::Cuint
@@ -10790,6 +11595,11 @@ struct __pthread_mutex_s
     __list::__pthread_list_t
 end
 
+"""
+    __JL_Ctag_1239
+
+Documentation not found
+"""
 struct __JL_Ctag_1239
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10812,6 +11622,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1239}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1240
+
+Documentation not found
+"""
 struct __JL_Ctag_1240
     si_tid::Cint
     si_overrun::Cint
@@ -10836,6 +11651,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1240}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1241
+
+Documentation not found
+"""
 struct __JL_Ctag_1241
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10860,6 +11680,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1241}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1242
+
+Documentation not found
+"""
 struct __JL_Ctag_1242
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10888,6 +11713,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1242}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1243
+
+Documentation not found
+"""
 struct __JL_Ctag_1243
     si_addr::Ptr{Cvoid}
 end
@@ -10908,6 +11738,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1243}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1244
+
+Documentation not found
+"""
 struct __JL_Ctag_1244
     si_band::Clong
     si_fd::Cint
@@ -10930,6 +11765,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1244}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1245
+
+Documentation not found
+"""
 struct __JL_Ctag_1245
     _call_addr::Ptr{Cvoid}
     _syscall::Cint
@@ -10954,38 +11794,86 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1245}, f::Symbol, v)
 end
 
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10994,18 +11882,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 64
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -11014,15 +11923,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,39 +1,39 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const __uid_t = Cuint
 
 """
-Documentation not found
+Documentation not found.
 """
 const __pid_t = Cint
 
 """
-Documentation not found
+Documentation not found.
 """
 const __clock_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const __time_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = __time_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = Culong
 
 """
     __pthread_internal_list
 
-Documentation not found
+Documentation not found.
 """
 struct __pthread_internal_list
     __prev::Ptr{__pthread_internal_list}
@@ -41,14 +41,14 @@ struct __pthread_internal_list
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const __pthread_list_t = __pthread_internal_list
 
 """
     pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_mutex_t
     data::NTuple{40, UInt8}
@@ -75,7 +75,7 @@ end
 """
     pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_cond_t
     data::NTuple{48, UInt8}
@@ -100,14 +100,14 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = Cint
 
 """
     pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_rwlock_t
     data::NTuple{56, UInt8}
@@ -134,7 +134,7 @@ end
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -153,7 +153,7 @@ end
 """
     sigval
 
-Documentation not found
+Documentation not found.
 """
 struct sigval
     data::NTuple{8, UInt8}
@@ -177,14 +177,14 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const sigval_t = sigval
 
 """
     __JL_Ctag_1238
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1238
     data::NTuple{112, UInt8}
@@ -216,7 +216,7 @@ end
 """
     siginfo_t
 
-Documentation not found
+Documentation not found.
 """
 struct siginfo_t
     data::NTuple{128, UInt8}
@@ -271,7 +271,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -675,7 +675,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -688,7 +688,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -701,7 +701,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -714,7 +714,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -741,7 +741,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -754,7 +754,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -767,7 +767,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -780,7 +780,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -961,7 +961,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -974,7 +974,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -987,7 +987,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -1000,7 +1000,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -1013,7 +1013,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -1026,7 +1026,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -1039,7 +1039,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1052,7 +1052,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1065,7 +1065,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1078,7 +1078,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1091,7 +1091,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1104,7 +1104,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1117,7 +1117,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1130,7 +1130,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1143,7 +1143,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1156,7 +1156,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1169,7 +1169,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1182,7 +1182,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1195,7 +1195,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1208,7 +1208,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1221,7 +1221,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1234,7 +1234,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1247,7 +1247,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1260,7 +1260,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1273,7 +1273,7 @@ end
 """
     __JL_Ctag_39
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_39::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1282,7 +1282,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1671,7 +1671,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1682,7 +1682,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2123,7 +2123,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2380,7 +2380,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2477,7 +2477,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3104,7 +3104,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3117,7 +3117,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3130,7 +3130,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3143,7 +3143,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3156,7 +3156,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3687,7 +3687,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3711,7 +3711,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -4031,7 +4031,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4076,7 +4076,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4107,7 +4107,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4168,7 +4168,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4181,7 +4181,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4194,7 +4194,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4207,7 +4207,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4306,7 +4306,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4374,7 +4374,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4451,13 +4451,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4499,7 +4499,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4511,14 +4511,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4584,7 +4584,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4650,7 +4650,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4679,7 +4679,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4716,7 +4716,7 @@ end
 """
     __JL_Ctag_280
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_280::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4726,7 +4726,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4738,7 +4738,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4758,7 +4758,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4773,7 +4773,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4921,7 +4921,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4934,7 +4934,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4947,7 +4947,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4960,7 +4960,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4973,7 +4973,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4986,7 +4986,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4999,7 +4999,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -5012,7 +5012,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -5025,7 +5025,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -5038,7 +5038,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5051,7 +5051,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5400,7 +5400,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5441,7 +5441,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5453,10 +5453,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5468,7 +5468,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5479,7 +5479,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5494,7 +5494,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5507,7 +5507,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5550,7 +5550,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5603,7 +5603,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5616,7 +5616,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5625,7 +5625,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5786,7 +5786,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5827,7 +5827,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5924,14 +5924,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5942,7 +5942,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6182,7 +6182,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6260,7 +6260,7 @@ end
 """
     __JL_Ctag_424
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_424::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6283,7 +6283,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6294,7 +6294,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6420,7 +6420,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6438,7 +6438,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6650,7 +6650,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6745,7 +6745,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6756,10 +6756,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6777,10 +6777,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6798,9 +6798,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6818,10 +6818,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6839,9 +6839,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6859,9 +6859,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6877,10 +6877,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6896,10 +6896,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6915,10 +6915,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6936,11 +6936,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6956,10 +6956,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6975,10 +6975,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6994,10 +6994,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -7019,11 +7019,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -7041,10 +7041,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7060,10 +7060,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7079,9 +7079,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7097,10 +7097,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7122,11 +7122,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7142,11 +7142,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7162,9 +7162,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7180,9 +7180,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7198,9 +7198,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7216,9 +7216,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7234,9 +7234,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7252,9 +7252,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7270,9 +7270,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7290,7 +7290,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7310,10 +7310,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7333,10 +7333,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7352,10 +7352,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7529,7 +7529,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7612,20 +7612,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7634,20 +7634,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7729,20 +7729,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7765,7 +7765,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7792,7 +7792,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7838,7 +7838,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7934,7 +7934,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7979,7 +7979,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7990,7 +7990,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -8000,7 +8000,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8060,10 +8060,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8093,10 +8093,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8138,7 +8138,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8283,24 +8283,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_656
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_656::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8385,7 +8385,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8396,7 +8396,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8625,7 +8625,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8641,9 +8641,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8657,7 +8657,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8668,7 +8668,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8679,7 +8679,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8737,7 +8737,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8750,7 +8750,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8935,7 +8935,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8953,7 +8953,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8965,7 +8965,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8983,9 +8983,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -9001,9 +9001,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9158,7 +9158,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9209,7 +9209,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9236,7 +9236,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9263,7 +9263,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9274,7 +9274,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9408,7 +9408,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9499,7 +9501,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9610,7 +9612,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9712,7 +9714,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9723,7 +9725,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9731,7 +9733,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9754,7 +9756,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9767,7 +9769,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -10008,7 +10010,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -10033,7 +10035,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10106,7 +10108,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10174,7 +10176,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10273,7 +10275,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10305,7 +10307,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10315,14 +10317,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10347,7 +10349,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10521,7 +10523,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10600,7 +10602,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10812,7 +10814,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -11029,7 +11031,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11047,7 +11049,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11060,7 +11062,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11073,7 +11075,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11086,7 +11088,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11097,14 +11099,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11126,7 +11128,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11427,26 +11429,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11460,7 +11462,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11473,7 +11475,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -11486,7 +11488,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11499,7 +11501,7 @@ end
 """
     __JL_Ctag_1184
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1184
     __lock::Cint
@@ -11538,7 +11540,7 @@ end
 """
     __JL_Ctag_1185
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1185
     __lock::Cint
@@ -11583,7 +11585,7 @@ end
 """
     __pthread_mutex_s
 
-Documentation not found
+Documentation not found.
 """
 struct __pthread_mutex_s
     __lock::Cint
@@ -11598,7 +11600,7 @@ end
 """
     __JL_Ctag_1239
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1239
     si_pid::__pid_t
@@ -11625,7 +11627,7 @@ end
 """
     __JL_Ctag_1240
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1240
     si_tid::Cint
@@ -11654,7 +11656,7 @@ end
 """
     __JL_Ctag_1241
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1241
     si_pid::__pid_t
@@ -11683,7 +11685,7 @@ end
 """
     __JL_Ctag_1242
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1242
     si_pid::__pid_t
@@ -11716,7 +11718,7 @@ end
 """
     __JL_Ctag_1243
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1243
     si_addr::Ptr{Cvoid}
@@ -11741,7 +11743,7 @@ end
 """
     __JL_Ctag_1244
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1244
     si_band::Clong
@@ -11768,7 +11770,7 @@ end
 """
     __JL_Ctag_1245
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1245
     _call_addr::Ptr{Cvoid}
@@ -11795,84 +11797,84 @@ end
 
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11883,37 +11885,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 64
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11924,32 +11926,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,57 +1,122 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const __darwin_time_t = Clong
 
+"""
+Documentation not found
+"""
 const __darwin_pid_t = Int32
 
+"""
+Documentation not found
+"""
 const __darwin_uid_t = UInt32
 
+"""
+    __darwin_pthread_handler_rec
+
+Documentation not found
+"""
 struct __darwin_pthread_handler_rec
     __routine::Ptr{Cvoid}
     __arg::Ptr{Cvoid}
     __next::Ptr{__darwin_pthread_handler_rec}
 end
 
+"""
+    _opaque_pthread_cond_t
+
+Documentation not found
+"""
 struct _opaque_pthread_cond_t
     __sig::Clong
     __opaque::NTuple{40, Cchar}
 end
 
+"""
+    _opaque_pthread_mutex_t
+
+Documentation not found
+"""
 struct _opaque_pthread_mutex_t
     __sig::Clong
     __opaque::NTuple{56, Cchar}
 end
 
+"""
+    _opaque_pthread_once_t
+
+Documentation not found
+"""
 struct _opaque_pthread_once_t
     __sig::Clong
     __opaque::NTuple{8, Cchar}
 end
 
+"""
+    _opaque_pthread_rwlock_t
+
+Documentation not found
+"""
 struct _opaque_pthread_rwlock_t
     __sig::Clong
     __opaque::NTuple{192, Cchar}
 end
 
+"""
+    _opaque_pthread_t
+
+Documentation not found
+"""
 struct _opaque_pthread_t
     __sig::Clong
     __cleanup_stack::Ptr{__darwin_pthread_handler_rec}
     __opaque::NTuple{8176, Cchar}
 end
 
+"""
+Documentation not found
+"""
 const __darwin_pthread_cond_t = _opaque_pthread_cond_t
 
+"""
+Documentation not found
+"""
 const __darwin_pthread_mutex_t = _opaque_pthread_mutex_t
 
+"""
+Documentation not found
+"""
 const __darwin_pthread_once_t = _opaque_pthread_once_t
 
+"""
+Documentation not found
+"""
 const __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t
 
+"""
+Documentation not found
+"""
 const __darwin_pthread_t = Ptr{_opaque_pthread_t}
 
+"""
+Documentation not found
+"""
 const pid_t = __darwin_pid_t
 
+"""
+Documentation not found
+"""
 const uid_t = __darwin_uid_t
 
+"""
+    sigval
+
+Documentation not found
+"""
 struct sigval
     data::NTuple{8, UInt8}
 end
@@ -73,6 +138,11 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __siginfo
+
+Documentation not found
+"""
 struct __siginfo
     data::NTuple{104, UInt8}
 end
@@ -102,20 +172,46 @@ function Base.setproperty!(x::Ptr{__siginfo}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const siginfo_t = __siginfo
 
+"""
+Documentation not found
+"""
 const time_t = __darwin_time_t
 
+"""
+Documentation not found
+"""
 const pthread_cond_t = __darwin_pthread_cond_t
 
+"""
+Documentation not found
+"""
 const pthread_mutex_t = __darwin_pthread_mutex_t
 
+"""
+Documentation not found
+"""
 const pthread_once_t = __darwin_pthread_once_t
 
+"""
+Documentation not found
+"""
 const pthread_rwlock_t = __darwin_pthread_rwlock_t
 
+"""
+Documentation not found
+"""
 const pthread_t = __darwin_pthread_t
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -130,6 +226,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -155,6 +256,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -167,6 +269,8 @@ end
 """
     aws_aligned_allocator()
 
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
+
 ### Prototype
 ```c
 struct aws_allocator *aws_aligned_allocator(void);
@@ -176,8 +280,14 @@ function aws_aligned_allocator()
     ccall((:aws_aligned_allocator, libaws_c_common), Ptr{aws_allocator}, ())
 end
 
+"""
+Avoid pulling in CoreFoundation headers in a header file.
+"""
 mutable struct __CFAllocator end
 
+"""
+Documentation not found
+"""
 const CFAllocatorRef = Ptr{__CFAllocator}
 
 """
@@ -266,6 +376,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -274,6 +389,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -287,6 +404,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -298,6 +417,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -311,6 +432,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -322,6 +445,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -335,6 +460,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -346,6 +473,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -359,6 +488,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -370,6 +501,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -383,6 +516,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -395,6 +530,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -406,6 +543,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -559,6 +698,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -571,6 +711,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -583,6 +724,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -595,6 +737,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -621,6 +764,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -633,6 +777,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -645,6 +790,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -657,6 +803,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -837,6 +984,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -849,6 +997,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -861,6 +1010,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -873,6 +1023,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -885,6 +1036,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -897,6 +1049,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -909,6 +1062,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -921,6 +1075,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -933,6 +1088,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -945,6 +1101,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -957,6 +1114,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -969,6 +1127,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -981,6 +1140,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -993,6 +1153,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1005,6 +1166,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1017,6 +1179,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1029,6 +1192,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1041,6 +1205,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1053,6 +1218,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1065,6 +1231,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1077,6 +1244,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1089,6 +1257,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1101,6 +1270,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1113,6 +1283,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1122,10 +1293,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_13
+
+Documentation not found
+"""
 @cenum __JL_Ctag_13::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1513,6 +1694,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1522,6 +1704,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1533,6 +1718,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1954,6 +2146,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2210,6 +2403,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2306,6 +2500,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2932,6 +3127,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2944,6 +3140,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2956,6 +3153,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2968,6 +3166,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2980,6 +3179,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3507,6 +3707,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3526,6 +3731,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3844,6 +4054,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3885,6 +4096,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3911,6 +4127,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3956,6 +4177,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3968,6 +4191,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3980,6 +4204,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -3992,6 +4217,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4004,6 +4230,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4099,6 +4326,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4162,6 +4394,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4184,6 +4421,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4278,6 +4522,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4288,8 +4533,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4351,6 +4604,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4412,6 +4670,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4438,6 +4701,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4470,11 +4736,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_84
+
+Documentation not found
+"""
 @cenum __JL_Ctag_84::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4482,6 +4758,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4497,6 +4778,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4507,6 +4793,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4653,6 +4944,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4665,6 +4957,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4677,6 +4970,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4689,6 +4983,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4701,6 +4996,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4713,6 +5009,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4725,6 +5022,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4737,6 +5035,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4749,6 +5048,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4761,6 +5061,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4773,6 +5074,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4883,6 +5185,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4894,6 +5198,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4907,6 +5213,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4918,6 +5226,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4931,6 +5241,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4942,6 +5254,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4955,6 +5269,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4966,6 +5282,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4979,6 +5297,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4990,6 +5310,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -5003,6 +5325,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5014,6 +5338,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5027,6 +5353,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5038,6 +5366,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5051,6 +5381,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5062,6 +5394,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5075,6 +5409,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5084,6 +5420,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5094,6 +5435,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5107,6 +5450,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5116,6 +5461,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5140,6 +5490,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5164,6 +5517,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5176,6 +5530,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5215,6 +5570,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5223,6 +5583,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5236,6 +5598,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5248,6 +5612,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5257,6 +5623,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5265,16 +5636,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5288,6 +5669,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5299,6 +5682,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5312,6 +5697,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5323,6 +5710,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5336,6 +5725,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5347,6 +5738,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5360,6 +5753,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5372,6 +5767,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5383,6 +5780,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5410,6 +5809,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5447,6 +5847,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5541,14 +5946,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5829,6 +6247,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5841,6 +6267,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5850,6 +6280,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_127
+
+Documentation not found
+"""
 @cenum __JL_Ctag_127::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5868,12 +6303,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6228,6 +6673,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6321,6 +6767,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7185,33 +7634,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7221,6 +7706,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7234,6 +7723,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7246,6 +7739,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7256,22 +7751,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7294,6 +7812,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7308,6 +7831,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7320,6 +7847,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7329,6 +7858,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7336,6 +7870,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7349,6 +7885,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7361,6 +7899,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7372,6 +7912,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7412,6 +7954,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7443,21 +7990,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_194
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_194::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7471,6 +8038,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7586,6 +8160,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7647,6 +8224,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7659,6 +8238,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7670,6 +8251,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7722,12 +8305,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_201
+
+Documentation not found
+"""
 @cenum __JL_Ctag_201::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7803,14 +8400,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8067,12 +8677,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8140,6 +8760,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8152,6 +8773,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8175,10 +8797,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8192,6 +8819,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8203,6 +8832,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8216,6 +8847,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8227,6 +8860,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8240,6 +8875,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8251,6 +8888,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8264,6 +8903,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8275,6 +8916,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8288,6 +8931,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8300,6 +8945,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8310,14 +8957,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8408,6 +9068,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8516,6 +9178,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8565,6 +9232,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8591,6 +9259,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8617,6 +9286,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8626,8 +9296,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_260
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_260::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8665,12 +9343,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8835,6 +9522,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9044,17 +9732,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9076,6 +9777,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9088,6 +9790,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9160,6 +9863,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9171,6 +9876,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9226,6 +9933,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9237,6 +9946,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9250,6 +9961,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9262,6 +9975,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9273,6 +9988,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9300,6 +10017,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9309,6 +10028,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9317,6 +10041,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9327,6 +10053,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9338,6 +10069,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_369
+
+honor the ABI compat
+"""
 struct __JL_Ctag_369
     data::NTuple{8, UInt8}
 end
@@ -9359,6 +10095,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_369}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{64, UInt8}
 end
@@ -9385,6 +10126,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9408,6 +10154,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9449,6 +10197,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9544,6 +10293,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9571,6 +10325,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9578,8 +10337,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9603,6 +10370,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9775,6 +10543,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9851,6 +10622,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10061,6 +10835,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10274,10 +11049,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_332
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_332::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10285,6 +11070,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10297,6 +11083,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10309,6 +11096,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10321,6 +11109,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10330,8 +11119,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10349,6 +11146,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10401,6 +11203,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10413,6 +11217,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10424,6 +11230,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10641,14 +11449,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10661,6 +11483,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10673,6 +11496,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -10685,6 +11509,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10694,38 +11519,86 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10734,18 +11607,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 64
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -10754,15 +11648,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,24 +1,24 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_time_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pid_t = Int32
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_uid_t = UInt32
 
 """
     __darwin_pthread_handler_rec
 
-Documentation not found
+Documentation not found.
 """
 struct __darwin_pthread_handler_rec
     __routine::Ptr{Cvoid}
@@ -29,7 +29,7 @@ end
 """
     _opaque_pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct _opaque_pthread_cond_t
     __sig::Clong
@@ -39,7 +39,7 @@ end
 """
     _opaque_pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct _opaque_pthread_mutex_t
     __sig::Clong
@@ -49,7 +49,7 @@ end
 """
     _opaque_pthread_once_t
 
-Documentation not found
+Documentation not found.
 """
 struct _opaque_pthread_once_t
     __sig::Clong
@@ -59,7 +59,7 @@ end
 """
     _opaque_pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct _opaque_pthread_rwlock_t
     __sig::Clong
@@ -69,7 +69,7 @@ end
 """
     _opaque_pthread_t
 
-Documentation not found
+Documentation not found.
 """
 struct _opaque_pthread_t
     __sig::Clong
@@ -78,44 +78,44 @@ struct _opaque_pthread_t
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pthread_cond_t = _opaque_pthread_cond_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pthread_mutex_t = _opaque_pthread_mutex_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pthread_once_t = _opaque_pthread_once_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const __darwin_pthread_t = Ptr{_opaque_pthread_t}
 
 """
-Documentation not found
+Documentation not found.
 """
 const pid_t = __darwin_pid_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const uid_t = __darwin_uid_t
 
 """
     sigval
 
-Documentation not found
+Documentation not found.
 """
 struct sigval
     data::NTuple{8, UInt8}
@@ -141,7 +141,7 @@ end
 """
     __siginfo
 
-Documentation not found
+Documentation not found.
 """
 struct __siginfo
     data::NTuple{104, UInt8}
@@ -173,44 +173,44 @@ function Base.setproperty!(x::Ptr{__siginfo}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const siginfo_t = __siginfo
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = __darwin_time_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_cond_t = __darwin_pthread_cond_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_mutex_t = __darwin_pthread_mutex_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = __darwin_pthread_once_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_rwlock_t = __darwin_pthread_rwlock_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = __darwin_pthread_t
 
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -256,7 +256,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -286,7 +286,7 @@ Avoid pulling in CoreFoundation headers in a header file.
 mutable struct __CFAllocator end
 
 """
-Documentation not found
+Documentation not found.
 """
 const CFAllocatorRef = Ptr{__CFAllocator}
 
@@ -698,7 +698,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -711,7 +711,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -724,7 +724,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -737,7 +737,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -764,7 +764,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -777,7 +777,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -790,7 +790,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -803,7 +803,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -984,7 +984,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -997,7 +997,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -1010,7 +1010,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -1023,7 +1023,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -1036,7 +1036,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -1049,7 +1049,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -1062,7 +1062,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1075,7 +1075,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1088,7 +1088,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1101,7 +1101,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1114,7 +1114,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1127,7 +1127,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1140,7 +1140,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1153,7 +1153,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1166,7 +1166,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1179,7 +1179,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1192,7 +1192,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1205,7 +1205,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1218,7 +1218,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1231,7 +1231,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1244,7 +1244,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1257,7 +1257,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1270,7 +1270,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1283,7 +1283,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1296,7 +1296,7 @@ end
 """
     __JL_Ctag_13
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_13::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1305,7 +1305,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1694,7 +1694,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1705,7 +1705,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2146,7 +2146,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2403,7 +2403,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2500,7 +2500,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3127,7 +3127,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3140,7 +3140,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3153,7 +3153,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3166,7 +3166,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3179,7 +3179,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3710,7 +3710,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3734,7 +3734,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -4054,7 +4054,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4099,7 +4099,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4130,7 +4130,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4191,7 +4191,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4204,7 +4204,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4217,7 +4217,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4230,7 +4230,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4329,7 +4329,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4397,7 +4397,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4474,13 +4474,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4522,7 +4522,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4534,14 +4534,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4607,7 +4607,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4673,7 +4673,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4702,7 +4702,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4739,7 +4739,7 @@ end
 """
     __JL_Ctag_84
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_84::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4749,7 +4749,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4761,7 +4761,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4781,7 +4781,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4796,7 +4796,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4944,7 +4944,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4957,7 +4957,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4970,7 +4970,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4983,7 +4983,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4996,7 +4996,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -5009,7 +5009,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -5022,7 +5022,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -5035,7 +5035,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -5048,7 +5048,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -5061,7 +5061,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5074,7 +5074,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5423,7 +5423,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5464,7 +5464,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5476,10 +5476,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5491,7 +5491,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5502,7 +5502,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5517,7 +5517,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5530,7 +5530,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5573,7 +5573,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5626,7 +5626,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5639,7 +5639,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5648,7 +5648,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5809,7 +5809,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5850,7 +5850,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5947,14 +5947,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5965,7 +5965,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6205,7 +6205,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6283,7 +6283,7 @@ end
 """
     __JL_Ctag_127
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_127::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6306,7 +6306,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6317,7 +6317,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6443,7 +6443,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6461,7 +6461,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6673,7 +6673,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6768,7 +6768,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6779,10 +6779,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6800,10 +6800,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6821,9 +6821,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6841,10 +6841,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6862,9 +6862,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6882,9 +6882,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6900,10 +6900,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6919,10 +6919,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6938,10 +6938,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6959,11 +6959,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6979,10 +6979,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6998,10 +6998,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -7017,10 +7017,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -7042,11 +7042,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -7064,10 +7064,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7083,10 +7083,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7102,9 +7102,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7120,10 +7120,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7145,11 +7145,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7165,11 +7165,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7185,9 +7185,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7203,9 +7203,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7221,9 +7221,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7239,9 +7239,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7257,9 +7257,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7275,9 +7275,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7293,9 +7293,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7313,7 +7313,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7333,10 +7333,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7356,10 +7356,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7375,10 +7375,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7552,7 +7552,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7635,20 +7635,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7657,20 +7657,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7752,20 +7752,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7788,7 +7788,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7815,7 +7815,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7861,7 +7861,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7957,7 +7957,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -8002,7 +8002,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -8013,7 +8013,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -8023,7 +8023,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8083,10 +8083,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8116,10 +8116,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8161,7 +8161,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8306,24 +8306,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_201
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_201::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8408,7 +8408,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8419,7 +8419,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8648,7 +8648,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8664,9 +8664,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8680,7 +8680,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8691,7 +8691,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8702,7 +8702,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8760,7 +8760,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8773,7 +8773,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8958,7 +8958,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8976,7 +8976,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8988,7 +8988,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -9006,9 +9006,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -9024,9 +9024,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9181,7 +9181,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9232,7 +9232,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9259,7 +9259,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9286,7 +9286,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9297,7 +9297,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9431,7 +9431,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9522,7 +9524,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9633,7 +9635,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9735,7 +9737,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9746,7 +9748,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9754,7 +9756,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9777,7 +9779,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9790,7 +9792,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -10031,7 +10033,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -10056,7 +10058,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10129,7 +10131,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10197,7 +10199,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10296,7 +10298,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10328,7 +10330,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10338,14 +10340,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10370,7 +10372,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10544,7 +10546,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10623,7 +10625,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10835,7 +10837,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -11052,7 +11054,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11070,7 +11072,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11083,7 +11085,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11096,7 +11098,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11109,7 +11111,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11120,14 +11122,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11149,7 +11151,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11450,26 +11452,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11483,7 +11485,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11496,7 +11498,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -11509,7 +11511,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11520,84 +11522,84 @@ function enable_vt_mode()
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11608,37 +11610,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 64
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11649,32 +11651,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1,24 +1,55 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const __uid_t = Cuint
 
+"""
+Documentation not found
+"""
 const __pid_t = Cint
 
+"""
+Documentation not found
+"""
 const __clock_t = Clong
 
+"""
+Documentation not found
+"""
 const __time_t = Clong
 
+"""
+Documentation not found
+"""
 const time_t = __time_t
 
+"""
+Documentation not found
+"""
 const pthread_t = Culong
 
+"""
+    __pthread_internal_list
+
+Documentation not found
+"""
 struct __pthread_internal_list
     __prev::Ptr{__pthread_internal_list}
     __next::Ptr{__pthread_internal_list}
 end
 
+"""
+Documentation not found
+"""
 const __pthread_list_t = __pthread_internal_list
 
+"""
+    pthread_mutex_t
+
+Documentation not found
+"""
 struct pthread_mutex_t
     data::NTuple{40, UInt8}
 end
@@ -41,6 +72,11 @@ function Base.setproperty!(x::Ptr{pthread_mutex_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_cond_t
+
+Documentation not found
+"""
 struct pthread_cond_t
     data::NTuple{48, UInt8}
 end
@@ -63,8 +99,16 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const pthread_once_t = Cint
 
+"""
+    pthread_rwlock_t
+
+Documentation not found
+"""
 struct pthread_rwlock_t
     data::NTuple{56, UInt8}
 end
@@ -87,6 +131,11 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -101,6 +150,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    sigval
+
+Documentation not found
+"""
 struct sigval
     data::NTuple{8, UInt8}
 end
@@ -122,8 +176,16 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const sigval_t = sigval
 
+"""
+    __JL_Ctag_1305
+
+Documentation not found
+"""
 struct __JL_Ctag_1305
     data::NTuple{112, UInt8}
 end
@@ -150,6 +212,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1305}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    siginfo
+
+Documentation not found
+"""
 struct siginfo
     data::NTuple{128, UInt8}
 end
@@ -173,8 +240,16 @@ function Base.setproperty!(x::Ptr{siginfo}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const siginfo_t = siginfo
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -200,6 +275,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -211,6 +287,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -279,6 +357,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -287,6 +370,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -300,6 +385,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -311,6 +398,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -324,6 +413,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -335,6 +426,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -348,6 +441,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -359,6 +454,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -372,6 +469,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -383,6 +482,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -396,6 +497,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -408,6 +511,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -419,6 +524,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -572,6 +679,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -584,6 +692,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -596,6 +705,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -608,6 +718,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -634,6 +745,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -646,6 +758,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -658,6 +771,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -670,6 +784,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -850,6 +965,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -862,6 +978,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -874,6 +991,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -886,6 +1004,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -898,6 +1017,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -910,6 +1030,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -922,6 +1043,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -934,6 +1056,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -946,6 +1069,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -958,6 +1082,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -970,6 +1095,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -982,6 +1108,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -994,6 +1121,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1006,6 +1134,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1018,6 +1147,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1030,6 +1160,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1042,6 +1173,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1054,6 +1186,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1066,6 +1199,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1078,6 +1212,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1090,6 +1225,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1102,6 +1238,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1114,6 +1251,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1126,6 +1264,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1135,10 +1274,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_41
+
+Documentation not found
+"""
 @cenum __JL_Ctag_41::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1526,6 +1675,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1535,6 +1685,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1546,6 +1699,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1967,6 +2127,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2223,6 +2384,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2319,6 +2481,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2945,6 +3108,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2957,6 +3121,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2969,6 +3134,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2981,6 +3147,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2993,6 +3160,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3520,6 +3688,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3539,6 +3712,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3857,6 +4035,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3898,6 +4077,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3924,6 +4108,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3969,6 +4158,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3981,6 +4172,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3993,6 +4185,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4005,6 +4198,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4017,6 +4211,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4112,6 +4307,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4175,6 +4375,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4197,6 +4402,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4291,6 +4503,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4301,8 +4514,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4364,6 +4585,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4425,6 +4651,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4451,6 +4682,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4483,11 +4717,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_292
+
+Documentation not found
+"""
 @cenum __JL_Ctag_292::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4495,6 +4739,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4510,6 +4759,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4520,6 +4774,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4666,6 +4925,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4678,6 +4938,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4690,6 +4951,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4702,6 +4964,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4714,6 +4977,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4726,6 +4990,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4738,6 +5003,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4750,6 +5016,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4762,6 +5029,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4774,6 +5042,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4786,6 +5055,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4896,6 +5166,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4907,6 +5179,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4920,6 +5194,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4931,6 +5207,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4944,6 +5222,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4955,6 +5235,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4968,6 +5250,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4979,6 +5263,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4992,6 +5278,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -5003,6 +5291,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -5016,6 +5306,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5027,6 +5319,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5040,6 +5334,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5051,6 +5347,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5064,6 +5362,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5075,6 +5375,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5088,6 +5390,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5097,6 +5401,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5107,6 +5416,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5120,6 +5431,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5129,6 +5442,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5153,6 +5471,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5177,6 +5498,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5189,6 +5511,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5228,6 +5551,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5236,6 +5564,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5249,6 +5579,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5261,6 +5593,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5270,6 +5604,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5278,16 +5617,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5301,6 +5650,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5312,6 +5663,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5325,6 +5678,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5336,6 +5691,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5349,6 +5706,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5360,6 +5719,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5373,6 +5734,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5385,6 +5748,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5396,6 +5761,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5423,6 +5790,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5460,6 +5828,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5554,14 +5927,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5842,6 +6228,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5854,6 +6248,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5863,6 +6261,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_443
+
+Documentation not found
+"""
 @cenum __JL_Ctag_443::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5881,12 +6284,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6241,6 +6654,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6334,6 +6748,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7198,33 +7615,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7234,6 +7687,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7247,6 +7704,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7259,6 +7720,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7269,22 +7732,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7307,6 +7793,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7321,6 +7812,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7333,6 +7828,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7342,6 +7839,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7349,6 +7851,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7362,6 +7866,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7374,6 +7880,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7385,6 +7893,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7425,6 +7935,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7456,21 +7971,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_660
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_660::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7484,6 +8019,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7599,6 +8141,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7660,6 +8205,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7672,6 +8219,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7683,6 +8232,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7735,12 +8286,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_681
+
+Documentation not found
+"""
 @cenum __JL_Ctag_681::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7816,14 +8381,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8080,12 +8658,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8153,6 +8741,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8165,6 +8754,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8188,10 +8778,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8205,6 +8800,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8216,6 +8813,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8229,6 +8828,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8240,6 +8841,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8253,6 +8856,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8264,6 +8869,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8277,6 +8884,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8288,6 +8897,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8301,6 +8912,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8313,6 +8926,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8323,14 +8938,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8421,6 +9049,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8529,6 +9159,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8578,6 +9213,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8604,6 +9240,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8630,6 +9267,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8639,8 +9277,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_884
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_884::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8678,12 +9324,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8848,6 +9503,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9057,17 +9713,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9089,6 +9758,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9101,6 +9771,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9173,6 +9844,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9184,6 +9857,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9239,6 +9914,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9250,6 +9927,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9263,6 +9942,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9275,6 +9956,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9286,6 +9969,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9313,6 +9998,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9322,6 +10009,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9330,6 +10022,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9340,6 +10034,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9351,6 +10050,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_1268
+
+honor the ABI compat
+"""
 struct __JL_Ctag_1268
     data::NTuple{8, UInt8}
 end
@@ -9372,6 +10076,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1268}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{64, UInt8}
 end
@@ -9398,6 +10107,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9421,6 +10135,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9462,6 +10178,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9557,6 +10274,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9584,6 +10306,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9591,8 +10318,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9616,6 +10351,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9788,6 +10524,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9864,6 +10603,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10074,6 +10816,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10287,10 +11030,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_1118
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_1118::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10298,6 +11051,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10310,6 +11064,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10322,6 +11077,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10334,6 +11090,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10343,8 +11100,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10362,6 +11127,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10414,6 +11184,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10426,6 +11198,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10437,6 +11211,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10654,14 +11430,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10674,6 +11464,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10686,6 +11477,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -10698,6 +11490,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10707,6 +11500,11 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+    __JL_Ctag_1223
+
+Documentation not found
+"""
 struct __JL_Ctag_1223
     __lock::Cint
     __nr_readers::Cuint
@@ -10747,6 +11545,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1223}, f::Symbol, v)
 end
 
 
+"""
+    __pthread_mutex_s
+
+Documentation not found
+"""
 struct __pthread_mutex_s
     __lock::Cint
     __count::Cuint
@@ -10757,6 +11560,11 @@ struct __pthread_mutex_s
     __list::__pthread_list_t
 end
 
+"""
+    __JL_Ctag_1224
+
+Documentation not found
+"""
 struct __JL_Ctag_1224
     __lock::Cint
     __futex::Cuint
@@ -10791,6 +11599,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1224}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1306
+
+Documentation not found
+"""
 struct __JL_Ctag_1306
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10813,6 +11626,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1306}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1307
+
+Documentation not found
+"""
 struct __JL_Ctag_1307
     si_tid::Cint
     si_overrun::Cint
@@ -10837,6 +11655,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1307}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1308
+
+Documentation not found
+"""
 struct __JL_Ctag_1308
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10861,6 +11684,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1308}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1309
+
+Documentation not found
+"""
 struct __JL_Ctag_1309
     si_pid::__pid_t
     si_uid::__uid_t
@@ -10889,6 +11717,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1309}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1310
+
+Documentation not found
+"""
 struct __JL_Ctag_1310
     si_addr::Ptr{Cvoid}
 end
@@ -10909,6 +11742,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1310}, f::Symbol, v)
 end
 
 
+"""
+    __JL_Ctag_1311
+
+Documentation not found
+"""
 struct __JL_Ctag_1311
     si_band::Clong
     si_fd::Cint
@@ -10931,38 +11769,86 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_1311}, f::Symbol, v)
 end
 
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10971,18 +11857,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 64
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -10991,15 +11898,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1,39 +1,39 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const __uid_t = Cuint
 
 """
-Documentation not found
+Documentation not found.
 """
 const __pid_t = Cint
 
 """
-Documentation not found
+Documentation not found.
 """
 const __clock_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const __time_t = Clong
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = __time_t
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = Culong
 
 """
     __pthread_internal_list
 
-Documentation not found
+Documentation not found.
 """
 struct __pthread_internal_list
     __prev::Ptr{__pthread_internal_list}
@@ -41,14 +41,14 @@ struct __pthread_internal_list
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const __pthread_list_t = __pthread_internal_list
 
 """
     pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_mutex_t
     data::NTuple{40, UInt8}
@@ -75,7 +75,7 @@ end
 """
     pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_cond_t
     data::NTuple{48, UInt8}
@@ -100,14 +100,14 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = Cint
 
 """
     pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_rwlock_t
     data::NTuple{56, UInt8}
@@ -134,7 +134,7 @@ end
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -153,7 +153,7 @@ end
 """
     sigval
 
-Documentation not found
+Documentation not found.
 """
 struct sigval
     data::NTuple{8, UInt8}
@@ -177,14 +177,14 @@ function Base.setproperty!(x::Ptr{sigval}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const sigval_t = sigval
 
 """
     __JL_Ctag_1305
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1305
     data::NTuple{112, UInt8}
@@ -215,7 +215,7 @@ end
 """
     siginfo
 
-Documentation not found
+Documentation not found.
 """
 struct siginfo
     data::NTuple{128, UInt8}
@@ -241,7 +241,7 @@ function Base.setproperty!(x::Ptr{siginfo}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const siginfo_t = siginfo
 
@@ -275,7 +275,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -679,7 +679,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -692,7 +692,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -705,7 +705,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -718,7 +718,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -745,7 +745,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -758,7 +758,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -771,7 +771,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -784,7 +784,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -965,7 +965,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -978,7 +978,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -991,7 +991,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -1004,7 +1004,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -1017,7 +1017,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -1030,7 +1030,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -1043,7 +1043,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1056,7 +1056,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1069,7 +1069,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1082,7 +1082,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1095,7 +1095,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1108,7 +1108,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1121,7 +1121,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1134,7 +1134,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1147,7 +1147,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1160,7 +1160,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1173,7 +1173,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1186,7 +1186,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1199,7 +1199,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1212,7 +1212,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1225,7 +1225,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1238,7 +1238,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1251,7 +1251,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1264,7 +1264,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1277,7 +1277,7 @@ end
 """
     __JL_Ctag_41
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_41::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1286,7 +1286,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1675,7 +1675,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1686,7 +1686,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2127,7 +2127,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2384,7 +2384,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2481,7 +2481,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3108,7 +3108,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3121,7 +3121,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3134,7 +3134,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3147,7 +3147,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3160,7 +3160,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3691,7 +3691,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3715,7 +3715,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -4035,7 +4035,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4080,7 +4080,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4111,7 +4111,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4172,7 +4172,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4185,7 +4185,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4198,7 +4198,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4211,7 +4211,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4310,7 +4310,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4378,7 +4378,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4455,13 +4455,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4503,7 +4503,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4515,14 +4515,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4588,7 +4588,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4654,7 +4654,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4683,7 +4683,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4720,7 +4720,7 @@ end
 """
     __JL_Ctag_292
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_292::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4730,7 +4730,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4742,7 +4742,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4762,7 +4762,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4777,7 +4777,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4925,7 +4925,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4938,7 +4938,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4951,7 +4951,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4964,7 +4964,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4977,7 +4977,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4990,7 +4990,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -5003,7 +5003,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -5016,7 +5016,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -5029,7 +5029,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -5042,7 +5042,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5055,7 +5055,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5404,7 +5404,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5445,7 +5445,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5457,10 +5457,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5472,7 +5472,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5483,7 +5483,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5498,7 +5498,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5511,7 +5511,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5554,7 +5554,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5607,7 +5607,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5620,7 +5620,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5629,7 +5629,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5790,7 +5790,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5831,7 +5831,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5928,14 +5928,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5946,7 +5946,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6186,7 +6186,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6264,7 +6264,7 @@ end
 """
     __JL_Ctag_443
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_443::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6287,7 +6287,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6298,7 +6298,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6424,7 +6424,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6442,7 +6442,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6654,7 +6654,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6749,7 +6749,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6760,10 +6760,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6781,10 +6781,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6802,9 +6802,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6822,10 +6822,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6843,9 +6843,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6863,9 +6863,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6881,10 +6881,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6900,10 +6900,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6919,10 +6919,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6940,11 +6940,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6960,10 +6960,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6979,10 +6979,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6998,10 +6998,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -7023,11 +7023,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -7045,10 +7045,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7064,10 +7064,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7083,9 +7083,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7101,10 +7101,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7126,11 +7126,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7146,11 +7146,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7166,9 +7166,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7184,9 +7184,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7202,9 +7202,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7220,9 +7220,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7238,9 +7238,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7256,9 +7256,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7274,9 +7274,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7294,7 +7294,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7314,10 +7314,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7337,10 +7337,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7356,10 +7356,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7533,7 +7533,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7616,20 +7616,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7638,20 +7638,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7733,20 +7733,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7769,7 +7769,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7796,7 +7796,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7842,7 +7842,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7938,7 +7938,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7983,7 +7983,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7994,7 +7994,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -8004,7 +8004,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8064,10 +8064,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8097,10 +8097,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8142,7 +8142,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8287,24 +8287,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_681
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_681::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8389,7 +8389,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8400,7 +8400,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8629,7 +8629,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8645,9 +8645,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8661,7 +8661,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8672,7 +8672,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8683,7 +8683,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8741,7 +8741,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8754,7 +8754,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8939,7 +8939,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8957,7 +8957,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8969,7 +8969,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8987,9 +8987,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -9005,9 +9005,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9162,7 +9162,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9213,7 +9213,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9240,7 +9240,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9267,7 +9267,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9278,7 +9278,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9412,7 +9412,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9503,7 +9505,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9614,7 +9616,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9716,7 +9718,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9727,7 +9729,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9735,7 +9737,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9758,7 +9760,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9771,7 +9773,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -10012,7 +10014,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -10037,7 +10039,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10110,7 +10112,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10178,7 +10180,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10277,7 +10279,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10309,7 +10311,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10319,14 +10321,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10351,7 +10353,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10525,7 +10527,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10604,7 +10606,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10816,7 +10818,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -11033,7 +11035,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11051,7 +11053,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11064,7 +11066,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11077,7 +11079,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11090,7 +11092,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11101,14 +11103,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11130,7 +11132,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11431,26 +11433,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11464,7 +11466,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11477,7 +11479,7 @@ end
 """
     s_print_stack_trace(sig, sig_info, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static void s_print_stack_trace(int sig, siginfo_t *sig_info, void *user_data);
@@ -11490,7 +11492,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11503,7 +11505,7 @@ end
 """
     __JL_Ctag_1223
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1223
     __lock::Cint
@@ -11548,7 +11550,7 @@ end
 """
     __pthread_mutex_s
 
-Documentation not found
+Documentation not found.
 """
 struct __pthread_mutex_s
     __lock::Cint
@@ -11563,7 +11565,7 @@ end
 """
     __JL_Ctag_1224
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1224
     __lock::Cint
@@ -11602,7 +11604,7 @@ end
 """
     __JL_Ctag_1306
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1306
     si_pid::__pid_t
@@ -11629,7 +11631,7 @@ end
 """
     __JL_Ctag_1307
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1307
     si_tid::Cint
@@ -11658,7 +11660,7 @@ end
 """
     __JL_Ctag_1308
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1308
     si_pid::__pid_t
@@ -11687,7 +11689,7 @@ end
 """
     __JL_Ctag_1309
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1309
     si_pid::__pid_t
@@ -11720,7 +11722,7 @@ end
 """
     __JL_Ctag_1310
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1310
     si_addr::Ptr{Cvoid}
@@ -11745,7 +11747,7 @@ end
 """
     __JL_Ctag_1311
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_1311
     si_band::Clong
@@ -11770,84 +11772,84 @@ end
 
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11858,37 +11860,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 64
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11899,32 +11901,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,7 +1,15 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const time_t = Clong
 
+"""
+    __JL_Ctag_328
+
+Documentation not found
+"""
 struct __JL_Ctag_328
     data::NTuple{40, UInt8}
 end
@@ -24,6 +32,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_328}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_mutex_t
+
+Documentation not found
+"""
 struct pthread_mutex_t
     data::NTuple{40, UInt8}
 end
@@ -44,6 +57,11 @@ function Base.setproperty!(x::Ptr{pthread_mutex_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __JL_Ctag_324
+
+Documentation not found
+"""
 struct __JL_Ctag_324
     data::NTuple{48, UInt8}
 end
@@ -66,6 +84,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_324}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_cond_t
+
+Documentation not found
+"""
 struct pthread_cond_t
     data::NTuple{48, UInt8}
 end
@@ -86,6 +109,11 @@ function Base.setproperty!(x::Ptr{pthread_cond_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    __JL_Ctag_331
+
+Documentation not found
+"""
 struct __JL_Ctag_331
     data::NTuple{56, UInt8}
 end
@@ -108,6 +136,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_331}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    pthread_rwlock_t
+
+Documentation not found
+"""
 struct pthread_rwlock_t
     data::NTuple{56, UInt8}
 end
@@ -128,12 +161,26 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 mutable struct __pthread end
 
+"""
+Documentation not found
+"""
 const pthread_t = Ptr{__pthread}
 
+"""
+Documentation not found
+"""
 const pthread_once_t = Cint
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -148,6 +195,11 @@ struct tm
     tm_zone::Ptr{Cchar}
 end
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -173,6 +225,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -184,6 +237,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -252,6 +307,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -260,6 +320,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -273,6 +335,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -284,6 +348,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -297,6 +363,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -308,6 +376,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -321,6 +391,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -332,6 +404,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -345,6 +419,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -356,6 +432,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -369,6 +447,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -381,6 +461,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -392,6 +474,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -545,6 +629,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -557,6 +642,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -569,6 +655,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -581,6 +668,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -607,6 +695,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -619,6 +708,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -631,6 +721,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -643,6 +734,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -823,6 +915,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -835,6 +928,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -847,6 +941,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -859,6 +954,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -871,6 +967,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -883,6 +980,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -895,6 +993,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -907,6 +1006,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -919,6 +1019,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -931,6 +1032,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -943,6 +1045,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -955,6 +1058,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -967,6 +1071,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -979,6 +1084,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -991,6 +1097,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1003,6 +1110,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1015,6 +1123,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1027,6 +1136,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1039,6 +1149,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1051,6 +1162,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1063,6 +1175,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1075,6 +1188,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1087,6 +1201,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1099,6 +1214,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1108,10 +1224,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_9
+
+Documentation not found
+"""
 @cenum __JL_Ctag_9::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1499,6 +1625,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1508,6 +1635,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1519,6 +1649,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1940,6 +2077,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2196,6 +2334,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2292,6 +2431,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2918,6 +3058,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2930,6 +3071,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2942,6 +3084,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2954,6 +3097,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2966,6 +3110,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3493,6 +3638,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3512,6 +3662,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3830,6 +3985,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3871,6 +4027,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3897,6 +4058,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3942,6 +4108,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3954,6 +4122,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3966,6 +4135,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -3978,6 +4148,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -3990,6 +4161,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4085,6 +4257,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4148,6 +4325,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4170,6 +4352,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4264,6 +4453,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4274,8 +4464,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4337,6 +4535,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4398,6 +4601,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4424,6 +4632,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4456,11 +4667,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_66
+
+Documentation not found
+"""
 @cenum __JL_Ctag_66::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4468,6 +4689,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4483,6 +4709,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4493,6 +4724,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4639,6 +4875,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4651,6 +4888,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4663,6 +4901,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4675,6 +4914,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4687,6 +4927,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4699,6 +4940,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4711,6 +4953,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4723,6 +4966,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4735,6 +4979,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4747,6 +4992,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4759,6 +5005,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4869,6 +5116,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4880,6 +5129,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4893,6 +5144,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4904,6 +5157,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4917,6 +5172,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4928,6 +5185,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4941,6 +5200,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4952,6 +5213,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4965,6 +5228,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4976,6 +5241,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -4989,6 +5256,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -5000,6 +5269,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -5013,6 +5284,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -5024,6 +5297,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -5037,6 +5312,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -5048,6 +5325,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -5061,6 +5340,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -5070,6 +5351,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -5080,6 +5366,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -5093,6 +5381,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5102,6 +5392,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5126,6 +5421,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5150,6 +5448,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5162,6 +5461,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5201,6 +5501,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5209,6 +5514,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5222,6 +5529,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5234,6 +5543,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5243,6 +5554,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5251,16 +5567,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5274,6 +5600,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5285,6 +5613,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5298,6 +5628,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5309,6 +5641,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5322,6 +5656,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5333,6 +5669,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5346,6 +5684,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5358,6 +5698,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5369,6 +5711,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5396,6 +5740,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5433,6 +5778,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5527,14 +5877,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5815,6 +6178,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5827,6 +6198,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5836,6 +6211,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_97
+
+Documentation not found
+"""
 @cenum __JL_Ctag_97::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5854,12 +6234,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6214,6 +6604,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6307,6 +6698,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7171,33 +7565,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7207,6 +7637,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7220,6 +7654,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7232,6 +7670,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7242,22 +7682,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7280,6 +7743,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7294,6 +7762,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7306,6 +7778,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7315,6 +7789,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7322,6 +7801,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7335,6 +7816,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7347,6 +7830,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7358,6 +7843,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7398,6 +7885,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7429,21 +7921,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_161
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_161::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7457,6 +7969,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7572,6 +8091,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7633,6 +8155,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7645,6 +8169,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7656,6 +8182,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7708,12 +8236,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_166
+
+Documentation not found
+"""
 @cenum __JL_Ctag_166::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7789,14 +8331,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -8053,12 +8608,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8126,6 +8691,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8138,6 +8704,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8161,10 +8728,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8178,6 +8750,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8189,6 +8763,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8202,6 +8778,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8213,6 +8791,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8226,6 +8806,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8237,6 +8819,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8250,6 +8834,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8261,6 +8847,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8274,6 +8862,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8286,6 +8876,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8296,14 +8888,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8394,6 +8999,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8502,6 +9109,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8551,6 +9163,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8577,6 +9190,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8603,6 +9217,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8612,8 +9227,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_221
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_221::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8651,12 +9274,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8821,6 +9453,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9030,17 +9663,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9062,6 +9708,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9074,6 +9721,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9146,6 +9794,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9157,6 +9807,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9212,6 +9864,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9223,6 +9877,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9236,6 +9892,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9248,6 +9906,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9259,6 +9919,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9286,6 +9948,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9295,6 +9959,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9303,6 +9972,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9313,6 +9984,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9324,6 +10000,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_320
+
+honor the ABI compat
+"""
 struct __JL_Ctag_320
     data::NTuple{8, UInt8}
 end
@@ -9345,6 +10026,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_320}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{64, UInt8}
 end
@@ -9371,6 +10057,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9394,6 +10085,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9435,6 +10128,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9530,6 +10224,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9557,6 +10256,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9564,8 +10268,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9589,6 +10301,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9761,6 +10474,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9837,6 +10553,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10047,6 +10766,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10260,10 +10980,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_275
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_275::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10271,6 +11001,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10283,6 +11014,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10295,6 +11027,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10307,6 +11040,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10316,8 +11050,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10335,6 +11077,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10387,6 +11134,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10399,6 +11148,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10410,6 +11161,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10627,14 +11380,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10647,6 +11414,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10659,6 +11427,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10668,38 +11437,86 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10708,18 +11525,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 64
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -10728,15 +11566,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,14 +1,14 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = Clong
 
 """
     __JL_Ctag_328
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_328
     data::NTuple{40, UInt8}
@@ -35,7 +35,7 @@ end
 """
     pthread_mutex_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_mutex_t
     data::NTuple{40, UInt8}
@@ -60,7 +60,7 @@ end
 """
     __JL_Ctag_324
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_324
     data::NTuple{48, UInt8}
@@ -87,7 +87,7 @@ end
 """
     pthread_cond_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_cond_t
     data::NTuple{48, UInt8}
@@ -112,7 +112,7 @@ end
 """
     __JL_Ctag_331
 
-Documentation not found
+Documentation not found.
 """
 struct __JL_Ctag_331
     data::NTuple{56, UInt8}
@@ -139,7 +139,7 @@ end
 """
     pthread_rwlock_t
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_rwlock_t
     data::NTuple{56, UInt8}
@@ -162,24 +162,24 @@ function Base.setproperty!(x::Ptr{pthread_rwlock_t}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct __pthread end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = Ptr{__pthread}
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = Cint
 
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -225,7 +225,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -629,7 +629,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -642,7 +642,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -655,7 +655,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -668,7 +668,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -695,7 +695,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -708,7 +708,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -721,7 +721,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -734,7 +734,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -915,7 +915,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -928,7 +928,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -941,7 +941,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -954,7 +954,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -967,7 +967,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -980,7 +980,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -993,7 +993,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -1006,7 +1006,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -1019,7 +1019,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -1032,7 +1032,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -1045,7 +1045,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -1058,7 +1058,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -1071,7 +1071,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -1084,7 +1084,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -1097,7 +1097,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1110,7 +1110,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1123,7 +1123,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1136,7 +1136,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1149,7 +1149,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1162,7 +1162,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1175,7 +1175,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1188,7 +1188,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1201,7 +1201,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1214,7 +1214,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1227,7 +1227,7 @@ end
 """
     __JL_Ctag_9
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_9::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1236,7 +1236,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1625,7 +1625,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1636,7 +1636,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -2077,7 +2077,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2334,7 +2334,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2431,7 +2431,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -3058,7 +3058,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -3071,7 +3071,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -3084,7 +3084,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -3097,7 +3097,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3110,7 +3110,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3641,7 +3641,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3665,7 +3665,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -3985,7 +3985,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -4030,7 +4030,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -4061,7 +4061,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4122,7 +4122,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4135,7 +4135,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4148,7 +4148,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4161,7 +4161,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4260,7 +4260,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4328,7 +4328,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4405,13 +4405,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4453,7 +4453,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4465,14 +4465,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4538,7 +4538,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4604,7 +4604,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4633,7 +4633,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4670,7 +4670,7 @@ end
 """
     __JL_Ctag_66
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_66::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4680,7 +4680,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4692,7 +4692,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4712,7 +4712,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4727,7 +4727,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4875,7 +4875,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4888,7 +4888,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4901,7 +4901,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4914,7 +4914,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4927,7 +4927,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4940,7 +4940,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4953,7 +4953,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4966,7 +4966,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4979,7 +4979,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4992,7 +4992,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -5005,7 +5005,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5354,7 +5354,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5395,7 +5395,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5407,10 +5407,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5422,7 +5422,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5433,7 +5433,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5448,7 +5448,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5461,7 +5461,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5504,7 +5504,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5557,7 +5557,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5570,7 +5570,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5579,7 +5579,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5740,7 +5740,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5781,7 +5781,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5878,14 +5878,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5896,7 +5896,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6136,7 +6136,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6214,7 +6214,7 @@ end
 """
     __JL_Ctag_97
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_97::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6237,7 +6237,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6248,7 +6248,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6374,7 +6374,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6392,7 +6392,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6604,7 +6604,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6699,7 +6699,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6710,10 +6710,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6731,10 +6731,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6752,9 +6752,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6772,10 +6772,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6793,9 +6793,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6813,9 +6813,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6831,10 +6831,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6850,10 +6850,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6869,10 +6869,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6890,11 +6890,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6910,10 +6910,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6929,10 +6929,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6948,10 +6948,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -6973,11 +6973,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -6995,10 +6995,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -7014,10 +7014,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -7033,9 +7033,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -7051,10 +7051,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -7076,11 +7076,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -7096,11 +7096,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7116,9 +7116,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7134,9 +7134,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7152,9 +7152,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7170,9 +7170,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7188,9 +7188,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7206,9 +7206,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7224,9 +7224,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7244,7 +7244,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7264,10 +7264,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7287,10 +7287,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7306,10 +7306,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7483,7 +7483,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7566,20 +7566,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7588,20 +7588,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7683,20 +7683,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7719,7 +7719,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7746,7 +7746,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7792,7 +7792,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7888,7 +7888,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7933,7 +7933,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7944,7 +7944,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -7954,7 +7954,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -8014,10 +8014,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -8047,10 +8047,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -8092,7 +8092,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8237,24 +8237,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_166
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_166::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8339,7 +8339,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8350,7 +8350,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8579,7 +8579,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8595,9 +8595,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8611,7 +8611,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8622,7 +8622,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8633,7 +8633,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8691,7 +8691,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8704,7 +8704,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8889,7 +8889,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8907,7 +8907,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8919,7 +8919,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8937,9 +8937,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -8955,9 +8955,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9112,7 +9112,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9163,7 +9163,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9190,7 +9190,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9217,7 +9217,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9228,7 +9228,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9362,7 +9362,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9453,7 +9455,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9564,7 +9566,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9666,7 +9668,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9677,7 +9679,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9685,7 +9687,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9708,7 +9710,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9721,7 +9723,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9962,7 +9964,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -9987,7 +9989,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10060,7 +10062,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10128,7 +10130,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10227,7 +10229,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10259,7 +10261,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10269,14 +10271,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10301,7 +10303,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10475,7 +10477,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10554,7 +10556,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10766,7 +10768,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10983,7 +10985,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11001,7 +11003,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11014,7 +11016,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11027,7 +11029,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11040,7 +11042,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11051,14 +11053,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11080,7 +11082,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11381,26 +11383,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11414,7 +11416,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11427,7 +11429,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11438,84 +11440,84 @@ function enable_vt_mode()
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11526,37 +11528,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 64
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11567,32 +11569,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/x86_64-unknown-freebsd.jl
+++ b/lib/x86_64-unknown-freebsd.jl
@@ -1,32 +1,75 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const __time_t = Int64
 
+"""
+Documentation not found
+"""
 mutable struct pthread end
 
+"""
+Documentation not found
+"""
 mutable struct pthread_cond end
 
+"""
+Documentation not found
+"""
 mutable struct pthread_mutex end
 
+"""
+Documentation not found
+"""
 mutable struct pthread_rwlock end
 
+"""
+Documentation not found
+"""
 const pthread_t = Ptr{pthread}
 
+"""
+Documentation not found
+"""
 const pthread_mutex_t = Ptr{pthread_mutex}
 
+"""
+Documentation not found
+"""
 const pthread_cond_t = Ptr{pthread_cond}
 
+"""
+    pthread_once
+
+Documentation not found
+"""
 struct pthread_once
     state::Cint
     mutex::pthread_mutex_t
 end
 
+"""
+Documentation not found
+"""
 const pthread_once_t = pthread_once
 
+"""
+Documentation not found
+"""
 const pthread_rwlock_t = Ptr{pthread_rwlock}
 
+"""
+Documentation not found
+"""
 const time_t = __time_t
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     tm_sec::Cint
     tm_min::Cint
@@ -44,6 +87,7 @@ end
 """
     pthread_once(arg1, arg2)
 
+Documentation not found
 ### Prototype
 ```c
 int pthread_once(pthread_once_t *, void (*) (void));
@@ -53,6 +97,11 @@ function pthread_once(arg1, arg2)
     ccall((:pthread_once, libaws_c_common), Cint, (Ptr{pthread_once_t}, Ptr{Cvoid}), arg1, arg2)
 end
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -78,6 +127,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -89,6 +139,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -157,6 +209,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -165,6 +222,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -178,6 +237,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -189,6 +250,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -202,6 +265,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -213,6 +278,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -226,6 +293,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -237,6 +306,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -250,6 +321,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -261,6 +334,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -274,6 +349,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -286,6 +363,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -297,6 +376,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -450,6 +531,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -462,6 +544,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -474,6 +557,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -486,6 +570,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -512,6 +597,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -524,6 +610,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -536,6 +623,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -548,6 +636,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -728,6 +817,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -740,6 +830,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -752,6 +843,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -764,6 +856,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -776,6 +869,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -788,6 +882,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -800,6 +895,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -812,6 +908,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -824,6 +921,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -836,6 +934,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -848,6 +947,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -860,6 +960,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -872,6 +973,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -884,6 +986,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -896,6 +999,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -908,6 +1012,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -920,6 +1025,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -932,6 +1038,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -944,6 +1051,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -956,6 +1064,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -968,6 +1077,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -980,6 +1090,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -992,6 +1103,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1004,6 +1116,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1013,10 +1126,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_15
+
+Documentation not found
+"""
 @cenum __JL_Ctag_15::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1404,6 +1527,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1413,6 +1537,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1424,6 +1551,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1845,6 +1979,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2101,6 +2236,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2197,6 +2333,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2823,6 +2960,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2835,6 +2973,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2847,6 +2986,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2859,6 +2999,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2871,6 +3012,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3398,6 +3540,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3417,6 +3564,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3735,6 +3887,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3776,6 +3929,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3802,6 +3960,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3847,6 +4010,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3859,6 +4024,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3871,6 +4037,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -3883,6 +4050,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -3895,6 +4063,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -3990,6 +4159,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4053,6 +4227,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4075,6 +4254,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4169,6 +4355,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4179,8 +4366,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::pthread_cond_t
     initialized::Bool
@@ -4242,6 +4437,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::pthread_mutex_t
     initialized::Bool
@@ -4303,6 +4503,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4329,6 +4534,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4361,11 +4569,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_96
+
+Documentation not found
+"""
 @cenum __JL_Ctag_96::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4373,6 +4591,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4388,6 +4611,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4398,6 +4626,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     timestamp::time_t
     milliseconds::UInt16
@@ -4544,6 +4777,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4556,6 +4790,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4568,6 +4803,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4580,6 +4816,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4592,6 +4829,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4604,6 +4842,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4616,6 +4855,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4628,6 +4868,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4640,6 +4881,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4652,6 +4894,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4664,6 +4907,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4774,6 +5018,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4785,6 +5031,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4798,6 +5046,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4809,6 +5059,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4822,6 +5074,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4833,6 +5087,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4846,6 +5102,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4857,6 +5115,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4870,6 +5130,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4881,6 +5143,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -4894,6 +5158,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -4905,6 +5171,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -4918,6 +5186,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -4929,6 +5199,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -4942,6 +5214,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -4953,6 +5227,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -4966,6 +5242,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -4975,6 +5253,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -4985,6 +5268,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -4998,6 +5283,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5007,6 +5294,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5031,6 +5323,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5055,6 +5350,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5067,6 +5363,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5106,6 +5403,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5114,6 +5416,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5127,6 +5431,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5139,6 +5445,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5148,6 +5456,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5156,16 +5469,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5179,6 +5502,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5190,6 +5515,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5203,6 +5530,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5214,6 +5543,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5227,6 +5558,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5238,6 +5571,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5251,6 +5586,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5263,6 +5600,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5274,6 +5613,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5301,6 +5642,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5338,6 +5680,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5432,14 +5779,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5720,6 +6080,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5732,6 +6100,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5741,6 +6113,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_146
+
+Documentation not found
+"""
 @cenum __JL_Ctag_146::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5759,12 +6136,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6119,6 +6506,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6212,6 +6600,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7076,33 +7467,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7112,6 +7539,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7125,6 +7556,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7137,6 +7572,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7147,22 +7584,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7185,6 +7645,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7199,6 +7664,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7211,6 +7680,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7220,6 +7691,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7227,6 +7703,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7240,6 +7718,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7252,6 +7732,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7263,6 +7745,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7303,6 +7787,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7334,21 +7823,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_212
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_212::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7362,6 +7871,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7477,6 +7993,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = pthread_t
 
 """
@@ -7538,6 +8057,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7550,6 +8071,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7561,6 +8084,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7613,12 +8138,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_220
+
+Documentation not found
+"""
 @cenum __JL_Ctag_220::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7694,14 +8233,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -7958,12 +8510,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8031,6 +8593,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8043,6 +8606,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8066,10 +8630,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8083,6 +8652,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8094,6 +8665,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8107,6 +8680,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8118,6 +8693,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8131,6 +8708,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8142,6 +8721,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8155,6 +8736,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8166,6 +8749,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8179,6 +8764,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8191,6 +8778,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8201,14 +8790,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8299,6 +8901,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8407,6 +9011,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
 end
@@ -8456,6 +9065,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8482,6 +9092,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8508,6 +9119,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8517,8 +9129,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_284
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_284::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8556,12 +9176,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8726,6 +9355,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -8935,17 +9565,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -8967,6 +9610,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -8979,6 +9623,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9051,6 +9696,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9062,6 +9709,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9117,6 +9766,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9128,6 +9779,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9141,6 +9794,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9153,6 +9808,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9164,6 +9821,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9191,6 +9850,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9200,6 +9861,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9208,6 +9874,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9218,6 +9886,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9229,6 +9902,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_399
+
+honor the ABI compat
+"""
 struct __JL_Ctag_399
     data::NTuple{8, UInt8}
 end
@@ -9250,6 +9928,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_399}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{64, UInt8}
 end
@@ -9276,6 +9959,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9299,6 +9987,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9340,6 +10030,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9435,6 +10126,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9462,6 +10158,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9469,8 +10170,16 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_once = pthread_once_t
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9494,6 +10203,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9666,6 +10376,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9742,6 +10455,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -9952,6 +10668,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10165,10 +10882,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_361
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_361::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10176,6 +10903,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10188,6 +10916,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10200,6 +10929,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10212,6 +10942,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10221,8 +10952,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10240,6 +10979,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10292,6 +11036,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10304,6 +11050,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10315,6 +11063,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10532,14 +11282,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10552,6 +11316,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10564,6 +11329,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10573,38 +11339,86 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('/')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "/"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10613,18 +11427,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 64
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -10633,15 +11468,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,49 +1,49 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const __time_t = Int64
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct pthread end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct pthread_cond end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct pthread_mutex end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct pthread_rwlock end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_t = Ptr{pthread}
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_mutex_t = Ptr{pthread_mutex}
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_cond_t = Ptr{pthread_cond}
 
 """
     pthread_once
 
-Documentation not found
+Documentation not found.
 """
 struct pthread_once
     state::Cint
@@ -51,24 +51,24 @@ struct pthread_once
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_once_t = pthread_once
 
 """
-Documentation not found
+Documentation not found.
 """
 const pthread_rwlock_t = Ptr{pthread_rwlock}
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = __time_t
 
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     tm_sec::Cint
@@ -87,7 +87,7 @@ end
 """
     pthread_once(arg1, arg2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int pthread_once(pthread_once_t *, void (*) (void));
@@ -127,7 +127,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -531,7 +531,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -544,7 +544,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -557,7 +557,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -570,7 +570,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -597,7 +597,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -610,7 +610,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -623,7 +623,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -636,7 +636,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -817,7 +817,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -830,7 +830,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -843,7 +843,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -856,7 +856,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -869,7 +869,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -882,7 +882,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -895,7 +895,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -908,7 +908,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -921,7 +921,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -934,7 +934,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -947,7 +947,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -960,7 +960,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -973,7 +973,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -986,7 +986,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -999,7 +999,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -1012,7 +1012,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -1025,7 +1025,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -1038,7 +1038,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1051,7 +1051,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1064,7 +1064,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1077,7 +1077,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1090,7 +1090,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1103,7 +1103,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1116,7 +1116,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1129,7 +1129,7 @@ end
 """
     __JL_Ctag_15
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_15::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1138,7 +1138,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1527,7 +1527,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1538,7 +1538,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -1979,7 +1979,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2236,7 +2236,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2333,7 +2333,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2960,7 +2960,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2973,7 +2973,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2986,7 +2986,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2999,7 +2999,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -3012,7 +3012,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3543,7 +3543,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3567,7 +3567,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -3887,7 +3887,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3932,7 +3932,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -3963,7 +3963,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -4024,7 +4024,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -4037,7 +4037,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4050,7 +4050,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4063,7 +4063,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4162,7 +4162,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4230,7 +4230,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4307,13 +4307,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4355,7 +4355,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4367,14 +4367,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::pthread_cond_t
@@ -4440,7 +4440,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::pthread_mutex_t
@@ -4506,7 +4506,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4535,7 +4535,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4572,7 +4572,7 @@ end
 """
     __JL_Ctag_96
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_96::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4582,7 +4582,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4594,7 +4594,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4614,7 +4614,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4629,7 +4629,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     timestamp::time_t
@@ -4777,7 +4777,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4790,7 +4790,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4803,7 +4803,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4816,7 +4816,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4829,7 +4829,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4842,7 +4842,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4855,7 +4855,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4868,7 +4868,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4881,7 +4881,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4894,7 +4894,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4907,7 +4907,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5256,7 +5256,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5297,7 +5297,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5309,10 +5309,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5324,7 +5324,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5335,7 +5335,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5350,7 +5350,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5363,7 +5363,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5406,7 +5406,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5459,7 +5459,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5472,7 +5472,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5481,7 +5481,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5642,7 +5642,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5683,7 +5683,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5780,14 +5780,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5798,7 +5798,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6038,7 +6038,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6116,7 +6116,7 @@ end
 """
     __JL_Ctag_146
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_146::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6139,7 +6139,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6150,7 +6150,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6276,7 +6276,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6294,7 +6294,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6506,7 +6506,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6601,7 +6601,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6612,10 +6612,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6633,10 +6633,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6654,9 +6654,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6674,10 +6674,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6695,9 +6695,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6715,9 +6715,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6733,10 +6733,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6752,10 +6752,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6771,10 +6771,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6792,11 +6792,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6812,10 +6812,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6831,10 +6831,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6850,10 +6850,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -6875,11 +6875,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -6897,10 +6897,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -6916,10 +6916,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -6935,9 +6935,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -6953,10 +6953,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -6978,11 +6978,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -6998,11 +6998,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -7018,9 +7018,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7036,9 +7036,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7054,9 +7054,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7072,9 +7072,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7090,9 +7090,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7108,9 +7108,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7126,9 +7126,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7146,7 +7146,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7166,10 +7166,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7189,10 +7189,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7208,10 +7208,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7385,7 +7385,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7468,20 +7468,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7490,20 +7490,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7585,20 +7585,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7621,7 +7621,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7648,7 +7648,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7694,7 +7694,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7790,7 +7790,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7835,7 +7835,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7846,7 +7846,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -7856,7 +7856,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -7916,10 +7916,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -7949,10 +7949,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -7994,7 +7994,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = pthread_t
 
@@ -8139,24 +8139,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_220
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_220::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8241,7 +8241,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8252,7 +8252,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8481,7 +8481,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8497,9 +8497,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8513,7 +8513,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8524,7 +8524,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8535,7 +8535,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8593,7 +8593,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8606,7 +8606,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8791,7 +8791,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8809,7 +8809,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8821,7 +8821,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8839,9 +8839,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -8857,9 +8857,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -9014,7 +9014,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::pthread_rwlock_t
@@ -9065,7 +9065,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9092,7 +9092,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9119,7 +9119,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9130,7 +9130,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9264,7 +9264,9 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
@@ -9355,7 +9357,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9466,7 +9468,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9568,7 +9570,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9579,7 +9581,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9587,7 +9589,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9610,7 +9612,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9623,7 +9625,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9864,7 +9866,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -9889,7 +9891,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -9962,7 +9964,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10030,7 +10032,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10129,7 +10131,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10161,7 +10163,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10171,14 +10173,14 @@ struct aws_thread_options
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_once = pthread_once_t
 
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10203,7 +10205,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10377,7 +10379,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10456,7 +10458,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10668,7 +10670,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10885,7 +10887,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -10903,7 +10905,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10916,7 +10918,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10929,7 +10931,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10942,7 +10944,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10953,14 +10955,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -10982,7 +10984,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11283,26 +11285,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11316,7 +11318,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11329,7 +11331,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11340,84 +11342,84 @@ function enable_vt_mode()
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = PTHREAD_COND_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('/')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "/"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11428,37 +11430,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 64
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = PTHREAD_MUTEX_INITIALIZER , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = PTHREAD_RWLOCK_INITIALIZER }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11469,32 +11471,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE_ATTRIBUTE __attribute__ ( ( always_inline , unused ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,9 +1,20 @@
 using CEnum
 
+"""
+Documentation not found
+"""
 const __time64_t = Clonglong
 
+"""
+Documentation not found
+"""
 const time_t = __time64_t
 
+"""
+    tm
+
+Documentation not found
+"""
 struct tm
     data::NTuple{36, UInt8}
 end
@@ -32,8 +43,16 @@ function Base.setproperty!(x::Ptr{tm}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+Documentation not found
+"""
 const LONG = Clong
 
+"""
+    aws_allocator
+
+Allocator structure. An instance of this will be passed around for anything needing memory allocation
+"""
 struct aws_allocator
     mem_acquire::Ptr{Cvoid}
     mem_release::Ptr{Cvoid}
@@ -59,6 +78,7 @@ end
 """
     aws_default_allocator()
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -70,6 +90,8 @@ end
 
 """
     aws_aligned_allocator()
+
+Allocator that align small allocations on 8 byte boundary and big allocations on 32/64 byte boundary.
 
 ### Prototype
 ```c
@@ -138,6 +160,11 @@ function aws_mem_realloc(allocator, ptr, oldsize, newsize)
     ccall((:aws_mem_realloc, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{Ptr{Cvoid}}, Csize_t, Csize_t), allocator, ptr, oldsize, newsize)
 end
 
+"""
+    aws_mem_trace_level
+
+Maintainer note: The above function doesn't return the pointer (as with standard C realloc) as this pattern becomes error-prone when OOMs occur. In particular, we want to avoid losing the old pointer when an OOM condition occurs, so we prefer to take the old pointer as an in/out reference argument that we can leave unchanged on failure.
+"""
 @cenum aws_mem_trace_level::UInt32 begin
     AWS_MEMTRACE_NONE = 0
     AWS_MEMTRACE_BYTES = 1
@@ -146,6 +173,8 @@ end
 
 """
     aws_mem_tracer_new(allocator, deprecated, level, frames_per_stack)
+
+Wraps an allocator and tracks all external allocations. If aws\\_mem\\_trace\\_dump() is called and there are still allocations active, they will be reported to the [`aws_logger`](@ref) at TRACE level. allocator - The allocator to wrap deprecated - Deprecated arg, ignored. level - The level to track allocations at frames\\_per\\_stack is how many frames to store per callstack if AWS\\_MEMTRACE\\_STACKS is in use, otherwise it is ignored. 8 tends to be a pretty good number balancing storage space vs useful stacks. Returns the tracer allocator, which should be used for all allocations that should be tracked.
 
 ### Prototype
 ```c
@@ -159,6 +188,8 @@ end
 """
     aws_mem_tracer_destroy(trace_allocator)
 
+Unwraps the traced allocator and cleans up the tracer. Returns the original allocator
+
 ### Prototype
 ```c
 struct aws_allocator *aws_mem_tracer_destroy(struct aws_allocator *trace_allocator);
@@ -170,6 +201,8 @@ end
 
 """
     aws_mem_tracer_dump(trace_allocator)
+
+If there are outstanding allocations, dumps them to log, along with any information gathered based on the trace level set when aws\\_mem\\_trace() was called. Should be passed the tracer allocator returned from aws\\_mem\\_trace().
 
 ### Prototype
 ```c
@@ -183,6 +216,8 @@ end
 """
     aws_mem_tracer_bytes(trace_allocator)
 
+Returns the current number of bytes in outstanding allocations
+
 ### Prototype
 ```c
 size_t aws_mem_tracer_bytes(struct aws_allocator *trace_allocator);
@@ -194,6 +229,8 @@ end
 
 """
     aws_mem_tracer_count(trace_allocator)
+
+Returns the current number of outstanding allocations
 
 ### Prototype
 ```c
@@ -207,6 +244,8 @@ end
 """
     aws_small_block_allocator_new(allocator, multi_threaded)
 
+Creates a new Small Block Allocator which fronts the supplied parent allocator. The SBA will intercept and handle small allocs, and will forward anything larger to the parent allocator. If multi\\_threaded is true, the internal allocator will protect its internal data structures with a mutex
+
 ### Prototype
 ```c
 struct aws_allocator *aws_small_block_allocator_new(struct aws_allocator *allocator, bool multi_threaded);
@@ -218,6 +257,8 @@ end
 
 """
     aws_small_block_allocator_destroy(sba_allocator)
+
+Destroys a Small Block Allocator instance and frees its memory to the parent allocator. The parent allocator will otherwise be unaffected.
 
 ### Prototype
 ```c
@@ -231,6 +272,8 @@ end
 """
     aws_small_block_allocator_bytes_active(sba_allocator)
 
+Returns the number of bytes currently active in the SBA
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_bytes_active(struct aws_allocator *sba_allocator);
@@ -242,6 +285,8 @@ end
 
 """
     aws_small_block_allocator_bytes_reserved(sba_allocator)
+
+Returns the number of bytes reserved in pages/bins inside the SBA, e.g. the current system memory used by the SBA
 
 ### Prototype
 ```c
@@ -255,6 +300,8 @@ end
 """
     aws_small_block_allocator_page_size(sba_allocator)
 
+Returns the page size that the SBA is using
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size(struct aws_allocator *sba_allocator);
@@ -267,6 +314,8 @@ end
 """
     aws_small_block_allocator_page_size_available(sba_allocator)
 
+Returns the amount of memory in each page available to user allocations
+
 ### Prototype
 ```c
 size_t aws_small_block_allocator_page_size_available(struct aws_allocator *sba_allocator);
@@ -278,6 +327,8 @@ end
 
 """
     aws_raise_error(err)
+
+Raises `err` to the installed callbacks, and sets the thread's error.
 
 ### Prototype
 ```c
@@ -431,6 +482,7 @@ end
 """
     aws_clz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -443,6 +495,7 @@ end
 """
     aws_clz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -455,6 +508,7 @@ end
 """
     aws_clz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -467,6 +521,7 @@ end
 """
     aws_clz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -493,6 +548,7 @@ end
 """
     aws_ctz_i32(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -505,6 +561,7 @@ end
 """
     aws_ctz_u64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -517,6 +574,7 @@ end
 """
     aws_ctz_i64(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -529,6 +587,7 @@ end
 """
     aws_ctz_size(n)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -709,6 +768,7 @@ end
 """
     aws_min_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -721,6 +781,7 @@ end
 """
     aws_max_u8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -733,6 +794,7 @@ end
 """
     aws_min_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -745,6 +807,7 @@ end
 """
     aws_max_i8(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -757,6 +820,7 @@ end
 """
     aws_min_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -769,6 +833,7 @@ end
 """
     aws_max_u16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -781,6 +846,7 @@ end
 """
     aws_min_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -793,6 +859,7 @@ end
 """
     aws_max_i16(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -805,6 +872,7 @@ end
 """
     aws_min_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -817,6 +885,7 @@ end
 """
     aws_max_u32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -829,6 +898,7 @@ end
 """
     aws_min_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -841,6 +911,7 @@ end
 """
     aws_max_i32(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -853,6 +924,7 @@ end
 """
     aws_min_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -865,6 +937,7 @@ end
 """
     aws_max_u64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -877,6 +950,7 @@ end
 """
     aws_min_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -889,6 +963,7 @@ end
 """
     aws_max_i64(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -901,6 +976,7 @@ end
 """
     aws_min_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -913,6 +989,7 @@ end
 """
     aws_max_size(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -925,6 +1002,7 @@ end
 """
     aws_min_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -937,6 +1015,7 @@ end
 """
     aws_max_int(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -949,6 +1028,7 @@ end
 """
     aws_min_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -961,6 +1041,7 @@ end
 """
     aws_max_float(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -973,6 +1054,7 @@ end
 """
     aws_min_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -985,6 +1067,7 @@ end
 """
     aws_max_double(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -994,10 +1077,20 @@ function aws_max_double(a, b)
     ccall((:aws_max_double, libaws_c_common), Cdouble, (Cdouble, Cdouble), a, b)
 end
 
+"""
+    __JL_Ctag_15
+
+Documentation not found
+"""
 @cenum __JL_Ctag_15::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
 end
 
+"""
+    aws_array_list
+
+Documentation not found
+"""
 struct aws_array_list
     alloc::Ptr{aws_allocator}
     current_size::Csize_t
@@ -1385,6 +1478,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1394,6 +1488,9 @@ function aws_fatal_assert(cond_str, file, line)
     ccall((:aws_fatal_assert, libaws_c_common), Cvoid, (Ptr{Cchar}, Ptr{Cchar}, Cint), cond_str, file, line)
 end
 
+"""
+Documentation not found
+"""
 const aws_atomic_impl_int_t = Csize_t
 
 """
@@ -1405,6 +1502,13 @@ struct aws_atomic_var
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_memory_order
+
+This enumeration specifies the memory ordering properties requested for a particular atomic operation. The atomic operation may provide stricter ordering than requested. Note that, within a single thread, all operations are still sequenced (that is, a thread sees its own atomic writes and reads happening in program order, but other threads may disagree on this ordering).
+
+The behavior of these memory orderings are the same as in the C11 atomics API; however, we only implement a subset that can be portably implemented on the compilers we target.
+"""
 @cenum aws_memory_order::UInt32 begin
     aws_memory_order_relaxed = 0
     aws_memory_order_acquire = 2
@@ -1826,6 +1930,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2082,6 +2187,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2178,6 +2284,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2804,6 +2911,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2816,6 +2924,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2828,6 +2937,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2840,6 +2950,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2852,6 +2963,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3379,6 +3491,11 @@ function aws_byte_cursor_utf8_parse_u64_hex(cursor, dst)
     ccall((:aws_byte_cursor_utf8_parse_u64_hex, libaws_c_common), Cint, (aws_byte_cursor, Ptr{UInt64}), cursor, dst)
 end
 
+"""
+    aws_linked_list_node
+
+Documentation not found
+"""
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
     prev::Ptr{aws_linked_list_node}
@@ -3398,6 +3515,11 @@ function aws_linked_list_node_reset(node)
     ccall((:aws_linked_list_node_reset, libaws_c_common), Cvoid, (Ptr{aws_linked_list_node},), node)
 end
 
+"""
+    aws_linked_list
+
+Documentation not found
+"""
 struct aws_linked_list
     head::aws_linked_list_node
     tail::aws_linked_list_node
@@ -3716,6 +3838,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3757,6 +3880,11 @@ function aws_linked_list_move_all_front(dst, src)
     ccall((:aws_linked_list_move_all_front, libaws_c_common), Cvoid, (Ptr{aws_linked_list}, Ptr{aws_linked_list}), dst, src)
 end
 
+"""
+    aws_cache_vtable
+
+Documentation not found
+"""
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
     find::Ptr{Cvoid}
@@ -3783,6 +3911,11 @@ This datastructure can be safely moved between threads, subject to the requireme
 """
 mutable struct hash_table_state end
 
+"""
+    aws_hash_table
+
+Documentation not found
+"""
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
 end
@@ -3828,6 +3961,8 @@ end
 """
     aws_cache_base_default_destroy(cache)
 
+Default implementations
+
 ### Prototype
 ```c
 void aws_cache_base_default_destroy(struct aws_cache *cache);
@@ -3840,6 +3975,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3852,6 +3988,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -3864,6 +4001,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -3876,6 +4014,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
+Documentation not found
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -3971,6 +4110,11 @@ function aws_cache_get_element_count(cache)
     ccall((:aws_cache_get_element_count, libaws_c_common), Csize_t, (Ptr{aws_cache},), cache)
 end
 
+"""
+    aws_timestamp_unit
+
+Documentation not found
+"""
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
     AWS_TIMESTAMP_MILLIS = 1000
@@ -4034,6 +4178,11 @@ function aws_sys_clock_get_ticks(timestamp)
     ccall((:aws_sys_clock_get_ticks, libaws_c_common), Cint, (Ptr{UInt64},), timestamp)
 end
 
+"""
+    aws_cli_options_has_arg
+
+Documentation not found
+"""
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
     AWS_CLI_OPTIONS_REQUIRED_ARGUMENT = 1
@@ -4056,6 +4205,13 @@ struct aws_cli_subcommand_dispatch
     command_name::Ptr{Cchar}
 end
 
+"""
+    aws_cli_option
+
+Ignoring padding since we're trying to maintain getopt.h compatibility
+
+NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
+"""
 struct aws_cli_option
     name::Ptr{Cchar}
     has_arg::aws_cli_options_has_arg
@@ -4150,6 +4306,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
+Documentation not found
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4160,8 +4317,16 @@ function aws_common_fatal_assert_library_initialized()
 end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
+"""
+Documentation not found
+"""
 const aws_condition_predicate_fn = Cvoid
 
+"""
+    aws_condition_variable
+
+Documentation not found
+"""
 struct aws_condition_variable
     condition_handle::Ptr{Cvoid}
     initialized::Bool
@@ -4223,6 +4388,11 @@ function aws_condition_variable_notify_all(condition_variable)
     ccall((:aws_condition_variable_notify_all, libaws_c_common), Cint, (Ptr{aws_condition_variable},), condition_variable)
 end
 
+"""
+    aws_mutex
+
+Documentation not found
+"""
 struct aws_mutex
     mutex_handle::Ptr{Cvoid}
     initialized::Bool
@@ -4284,6 +4454,11 @@ function aws_condition_variable_wait_for_pred(condition_variable, mutex, time_to
     ccall((:aws_condition_variable_wait_for_pred, libaws_c_common), Cint, (Ptr{aws_condition_variable}, Ptr{aws_mutex}, Int64, Ptr{aws_condition_predicate_fn}, Ptr{Cvoid}), condition_variable, mutex, time_to_wait, pred, pred_ctx)
 end
 
+"""
+    aws_cpu_feature_name
+
+Documentation not found
+"""
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
     AWS_CPU_FEATURE_SSE_4_1 = 1
@@ -4310,6 +4485,9 @@ function aws_cpu_has_feature(feature_name)
     ccall((:aws_cpu_has_feature, libaws_c_common), Bool, (aws_cpu_feature_name,), feature_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_cross_process_lock end
 
 """
@@ -4342,11 +4520,21 @@ function aws_cross_process_lock_release(instance_lock)
     ccall((:aws_cross_process_lock_release, libaws_c_common), Cvoid, (Ptr{aws_cross_process_lock},), instance_lock)
 end
 
+"""
+    __JL_Ctag_93
+
+Documentation not found
+"""
 @cenum __JL_Ctag_93::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
     AWS_DATE_TIME_STR_MAX_BASIC_LEN = 20
 end
 
+"""
+    aws_date_format
+
+Documentation not found
+"""
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
     AWS_DATE_FORMAT_ISO_8601 = 1
@@ -4354,6 +4542,11 @@ end
     AWS_DATE_FORMAT_AUTO_DETECT = 3
 end
 
+"""
+    aws_date_month
+
+Documentation not found
+"""
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
     AWS_DATE_MONTH_FEBRUARY = 1
@@ -4369,6 +4562,11 @@ end
     AWS_DATE_MONTH_DECEMBER = 11
 end
 
+"""
+    aws_date_day_of_week
+
+Documentation not found
+"""
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
     AWS_DATE_DAY_OF_WEEK_MONDAY = 1
@@ -4379,6 +4577,11 @@ end
     AWS_DATE_DAY_OF_WEEK_SATURDAY = 6
 end
 
+"""
+    aws_date_time
+
+Documentation not found
+"""
 struct aws_date_time
     data::NTuple{96, UInt8}
 end
@@ -4541,6 +4744,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
+Documentation not found
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4553,6 +4757,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4565,6 +4770,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4577,6 +4783,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4589,6 +4796,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4601,6 +4809,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4613,6 +4822,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4625,6 +4835,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4637,6 +4848,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4649,6 +4861,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4661,6 +4874,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -4771,6 +4985,8 @@ end
 """
     aws_hex_compute_encoded_len(to_encode_len, encoded_length)
 
+computes the length necessary to store the result of [`aws_hex_encode`](@ref)(). returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
+
 ### Prototype
 ```c
 int aws_hex_compute_encoded_len(size_t to_encode_len, size_t *encoded_length);
@@ -4782,6 +4998,8 @@ end
 
 """
     aws_hex_encode(to_encode, output)
+
+Base 16 (hex) encodes the contents of to\\_encode and stores the result in output. 0 terminates the result. Assumes the buffer is empty and does not resize on insufficient capacity.
 
 ### Prototype
 ```c
@@ -4795,6 +5013,8 @@ end
 """
     aws_hex_encode_append_dynamic(to_encode, output)
 
+Base 16 (hex) encodes the contents of to\\_encode and appends the result in output. Does not 0-terminate. Grows the destination buffer dynamically if necessary.
+
 ### Prototype
 ```c
 int aws_hex_encode_append_dynamic( const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4806,6 +5026,8 @@ end
 
 """
     aws_hex_compute_decoded_len(to_decode_len, decoded_len)
+
+computes the length necessary to store the result of [`aws_hex_decode`](@ref)(). returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4819,6 +5041,8 @@ end
 """
     aws_hex_decode(to_decode, output)
 
+Base 16 (hex) decodes the contents of to\\_decode and stores the result in output. If output is NULL, output\\_size will be set to what the output\\_size should be.
+
 ### Prototype
 ```c
 int aws_hex_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4830,6 +5054,8 @@ end
 
 """
     aws_base64_compute_encoded_len(to_encode_len, encoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_encode`](@ref) call. returns -1 on failure, and 0 on success. encoded\\_length will be set on success.
 
 ### Prototype
 ```c
@@ -4843,6 +5069,8 @@ end
 """
     aws_base64_encode(to_encode, output)
 
+Base 64 encodes the contents of to\\_encode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_encode(const struct aws_byte_cursor *AWS_RESTRICT to_encode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4854,6 +5082,8 @@ end
 
 """
     aws_base64_compute_decoded_len(to_decode, decoded_len)
+
+Computes the length necessary to store the output of [`aws_base64_decode`](@ref) call. returns -1 on failure, and 0 on success. decoded\\_len will be set on success.
 
 ### Prototype
 ```c
@@ -4867,6 +5097,8 @@ end
 """
     aws_base64_decode(to_decode, output)
 
+Base 64 decodes the contents of to\\_decode and stores the result in output.
+
 ### Prototype
 ```c
 int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output);
@@ -4878,6 +5110,8 @@ end
 
 """
     aws_write_u64(value, buffer)
+
+Add a 64 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 8 bytes.
 
 ### Prototype
 ```c
@@ -4891,6 +5125,8 @@ end
 """
     aws_read_u64(buffer)
 
+Extracts a 64 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer size is at least 8 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_read_u64(const uint8_t *buffer);
@@ -4902,6 +5138,8 @@ end
 
 """
     aws_write_u32(value, buffer)
+
+Add a 32 bit unsigned integer to the buffer, ensuring network - byte order Assumes the buffer size is at least 4 bytes.
 
 ### Prototype
 ```c
@@ -4915,6 +5153,8 @@ end
 """
     aws_read_u32(buffer)
 
+Extracts a 32 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes the buffer size is at least 4 bytes.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u32(const uint8_t *buffer);
@@ -4926,6 +5166,8 @@ end
 
 """
     aws_write_u24(value, buffer)
+
+Add a 24 bit unsigned integer to the buffer, ensuring network - byte order return the new position in the buffer for the next operation. Note, since this uses uint32\\_t for storage, the 3 least significant bytes will be used. Assumes buffer is at least 3 bytes long.
 
 ### Prototype
 ```c
@@ -4939,6 +5181,8 @@ end
 """
     aws_read_u24(buffer)
 
+Extracts a 24 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 3 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_read_u24(const uint8_t *buffer);
@@ -4950,6 +5194,8 @@ end
 
 """
     aws_write_u16(value, buffer)
+
+Add a 16 bit unsigned integer to the buffer, ensuring network-byte order return the new position in the buffer for the next operation. Assumes buffer is at least 2 bytes long.
 
 ### Prototype
 ```c
@@ -4963,6 +5209,8 @@ end
 """
     aws_read_u16(buffer)
 
+Extracts a 16 bit unsigned integer from buffer. Ensures conversion from network byte order to host byte order. Assumes buffer is at least 2 bytes long.
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_read_u16(const uint8_t *buffer);
@@ -4972,6 +5220,11 @@ function aws_read_u16(buffer)
     ccall((:aws_read_u16, libaws_c_common), UInt16, (Ptr{UInt8},), buffer)
 end
 
+"""
+    aws_text_encoding
+
+Documentation not found
+"""
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
     AWS_TEXT_UTF8 = 1
@@ -4982,6 +5235,8 @@ end
 
 """
     aws_text_detect_encoding(bytes, size)
+
+Checks the BOM in the buffer to see if encoding can be determined. If there is no BOM or it is unrecognizable, then AWS\\_TEXT\\_UNKNOWN will be returned.
 
 ### Prototype
 ```c
@@ -4995,6 +5250,8 @@ end
 """
     aws_text_is_utf8(bytes, size)
 
+Returns true if [`aws_text_detect_encoding`](@ref)() determines the text is UTF8 or ASCII. Note that this immediately returns true if the UTF8 BOM is seen. To fully validate every byte, use [`aws_decode_utf8`](@ref)().
+
 ### Prototype
 ```c
 AWS_STATIC_IMPL bool aws_text_is_utf8(const uint8_t *bytes, size_t size);
@@ -5004,6 +5261,11 @@ function aws_text_is_utf8(bytes, size)
     ccall((:aws_text_is_utf8, libaws_c_common), Bool, (Ptr{UInt8}, Csize_t), bytes, size)
 end
 
+"""
+    aws_utf8_decoder_options
+
+Documentation not found
+"""
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
     user_data::Ptr{Cvoid}
@@ -5028,6 +5290,9 @@ function aws_decode_utf8(bytes, options)
     ccall((:aws_decode_utf8, libaws_c_common), Cint, (aws_byte_cursor, Ptr{aws_utf8_decoder_options}), bytes, options)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_utf8_decoder end
 
 """
@@ -5052,6 +5317,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5064,6 +5330,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5103,6 +5370,11 @@ function aws_utf8_decoder_finalize(decoder)
     ccall((:aws_utf8_decoder_finalize, libaws_c_common), Cint, (Ptr{aws_utf8_decoder},), decoder)
 end
 
+"""
+    aws_string
+
+Documentation not found
+"""
 struct aws_string
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -5111,6 +5383,8 @@ end
 
 """
     aws_get_environment_value(allocator, variable_name, value_out)
+
+Get the value of an environment variable. If the variable is not set, the output string will be set to NULL. Not thread-safe
 
 ### Prototype
 ```c
@@ -5124,6 +5398,8 @@ end
 """
     aws_set_environment_value(variable_name, value)
 
+Set the value of an environment variable. On Windows, setting a variable to the empty string will actually unset it. Not thread-safe
+
 ### Prototype
 ```c
 int aws_set_environment_value(const struct aws_string *variable_name, const struct aws_string *value);
@@ -5136,6 +5412,8 @@ end
 """
     aws_unset_environment_value(variable_name)
 
+Unset an environment variable. Not thread-safe
+
 ### Prototype
 ```c
 int aws_unset_environment_value(const struct aws_string *variable_name);
@@ -5145,6 +5423,11 @@ function aws_unset_environment_value(variable_name)
     ccall((:aws_unset_environment_value, libaws_c_common), Cint, (Ptr{aws_string},), variable_name)
 end
 
+"""
+    aws_error_info
+
+Documentation not found
+"""
 struct aws_error_info
     error_code::Cint
     literal_name::Ptr{Cchar}
@@ -5153,16 +5436,26 @@ struct aws_error_info
     formatted_name::Ptr{Cchar}
 end
 
+"""
+    aws_error_info_list
+
+Documentation not found
+"""
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
     count::UInt16
 end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
+"""
+Documentation not found
+"""
 const aws_error_handler_fn = Cvoid
 
 """
     aws_last_error()
+
+Returns the latest error code on the current thread, or 0 if none have occurred.
 
 ### Prototype
 ```c
@@ -5176,6 +5469,8 @@ end
 """
     aws_error_str(err)
 
+Returns the error str corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_str(int err);
@@ -5187,6 +5482,8 @@ end
 
 """
     aws_error_name(err)
+
+Returns the enum name corresponding to `err`.
 
 ### Prototype
 ```c
@@ -5200,6 +5497,8 @@ end
 """
     aws_error_lib_name(err)
 
+Returns the error lib name corresponding to `err`.
+
 ### Prototype
 ```c
 const char *aws_error_lib_name(int err);
@@ -5211,6 +5510,8 @@ end
 
 """
     aws_error_debug_str(err)
+
+Returns libname concatenated with error string.
 
 ### Prototype
 ```c
@@ -5224,6 +5525,8 @@ end
 """
     aws_raise_error_private(err)
 
+Internal implementation detail.
+
 ### Prototype
 ```c
 void aws_raise_error_private(int err);
@@ -5235,6 +5538,8 @@ end
 
 """
     aws_reset_error()
+
+Resets the `err` back to defaults
 
 ### Prototype
 ```c
@@ -5248,6 +5553,8 @@ end
 """
     aws_restore_error(err)
 
+Sets `err` to the latest error. Does not invoke callbacks.
+
 ### Prototype
 ```c
 void aws_restore_error(int err);
@@ -5260,6 +5567,8 @@ end
 """
     aws_set_global_error_handler_fn(handler, ctx)
 
+Sets an application wide error handler function. This will be overridden by the thread local handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
+
 ### Prototype
 ```c
 aws_error_handler_fn *aws_set_global_error_handler_fn(aws_error_handler_fn *handler, void *ctx);
@@ -5271,6 +5580,8 @@ end
 
 """
     aws_set_thread_local_error_handler_fn(handler, ctx)
+
+Sets a thread-local error handler function. This will override the global handler. The previous handler is returned, this can be used for restoring an error handler if it needs to be overridden temporarily. Setting this to NULL will turn off this error callback after it has been enabled.
 
 ### Prototype
 ```c
@@ -5298,6 +5609,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5335,6 +5647,11 @@ function aws_translate_and_raise_io_error(error_no)
     ccall((:aws_translate_and_raise_io_error, libaws_c_common), Cint, (Cint,), error_no)
 end
 
+"""
+    aws_common_error
+
+Documentation not found
+"""
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
     AWS_ERROR_OOM = 1
@@ -5429,14 +5746,27 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
     ccall((:aws_cache_new_fifo, libaws_c_common), Ptr{aws_cache}, (Ptr{aws_allocator}, Ptr{aws_hash_fn}, Ptr{aws_hash_callback_eq_fn}, Ptr{aws_hash_callback_destroy_fn}, Ptr{aws_hash_callback_destroy_fn}, Csize_t), allocator, hash_fn, equals_fn, destroy_key_fn, destroy_value_fn, max_items)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_directory_iterator end
 
+"""
+    aws_file_type
+
+Documentation not found
+"""
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
     AWS_FILE_TYPE_SYM_LINK = 2
     AWS_FILE_TYPE_DIRECTORY = 4
 end
 
+"""
+    aws_directory_entry
+
+Documentation not found
+"""
 struct aws_directory_entry
     path::aws_byte_cursor
     relative_path::aws_byte_cursor
@@ -5717,6 +6047,14 @@ end
 """
     aws_fseek(file, offset, whence)
 
+Wrapper for highest-resolution platform-dependent seek implementation. Maps to:
+
+\\_fseeki64() on windows fseeko() on linux
+
+whence can either be SEEK\\_SET or SEEK\\_END
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
 ### Prototype
 ```c
 int aws_fseek(FILE *file, int64_t offset, int whence);
@@ -5729,6 +6067,10 @@ end
 """
     aws_file_get_length(file, length)
 
+Wrapper for os-specific file length query. We can't use fseek(END, 0) because support for it is not technically required.
+
+Unix flavors call fstat, while Windows variants use GetFileSize on a HANDLE queried from the libc FILE pointer.
+
 ### Prototype
 ```c
 int aws_file_get_length(FILE *file, int64_t *length);
@@ -5738,6 +6080,11 @@ function aws_file_get_length(file, length)
     ccall((:aws_file_get_length, libaws_c_common), Cint, (Ptr{Libc.FILE}, Ptr{Int64}), file, length)
 end
 
+"""
+    __JL_Ctag_143
+
+Documentation not found
+"""
 @cenum __JL_Ctag_143::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
     AWS_COMMON_HASH_TABLE_ITER_DELETE = 2
@@ -5756,12 +6103,22 @@ struct aws_hash_element
     value::Ptr{Cvoid}
 end
 
+"""
+    aws_hash_iter_status
+
+Documentation not found
+"""
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
     AWS_HASH_ITER_STATUS_DELETE_CALLED = 1
     AWS_HASH_ITER_STATUS_READY_FOR_USE = 2
 end
 
+"""
+    aws_hash_iter
+
+Documentation not found
+"""
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
     element::aws_hash_element
@@ -6116,6 +6473,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
+Documentation not found
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6209,6 +6567,9 @@ function aws_hash_iter_is_valid(iter)
     ccall((:aws_hash_iter_is_valid, libaws_c_common), Bool, (Ptr{aws_hash_iter},), iter)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_json_value end
 
 """
@@ -7073,33 +7434,69 @@ function aws_char_is_space(c)
 end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
+"""
+Documentation not found
+"""
 const aws_log_channel_clean_up_fn = Cvoid
 
+"""
+    aws_log_channel_vtable
+
+Documentation not found
+"""
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
     clean_up::Ptr{aws_log_channel_clean_up_fn}
 end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
+"""
+Documentation not found
+"""
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
+"""
+Documentation not found
+"""
 const aws_log_writer_clean_up_fn = Cvoid
 
+"""
+    aws_log_writer_vtable
+
+Documentation not found
+"""
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
     clean_up::Ptr{aws_log_writer_clean_up_fn}
 end
 
+"""
+    aws_log_writer
+
+Log writer interface and default implementation(s)
+
+A log writer functions as a sink for formatted log lines. We provide default implementations that go to stdout, stderr, and a specified file.
+"""
 struct aws_log_writer
     vtable::Ptr{aws_log_writer_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_channel
+
+Log channel interface and default implementations
+
+A log channel is an abstraction for the transfer of formatted log data between a source (formatter) and a sink (writer).
+"""
 struct aws_log_channel
     vtable::Ptr{aws_log_channel_vtable}
     allocator::Ptr{aws_allocator}
@@ -7109,6 +7506,10 @@ end
 
 """
     aws_log_channel_init_foreground(channel, allocator, writer)
+
+Simple channel that results in log lines being written in the same thread they were generated in.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
 
 ### Prototype
 ```c
@@ -7122,6 +7523,10 @@ end
 """
     aws_log_channel_init_background(channel, allocator, writer)
 
+Simple channel that sends log lines to a background thread.
+
+The passed in log writer is not an ownership transfer. The log channel does not clean up the writer.
+
 ### Prototype
 ```c
 int aws_log_channel_init_background( struct aws_log_channel *channel, struct aws_allocator *allocator, struct aws_log_writer *writer);
@@ -7134,6 +7539,8 @@ end
 """
     aws_log_channel_clean_up(channel)
 
+Channel cleanup function
+
 ### Prototype
 ```c
 void aws_log_channel_clean_up(struct aws_log_channel *channel);
@@ -7144,22 +7551,45 @@ function aws_log_channel_clean_up(channel)
 end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
+"""
+Documentation not found
+"""
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
+"""
+Documentation not found
+"""
 const aws_log_formatter_clean_up_fn = Cvoid
 
+"""
+    aws_log_formatter_vtable
+
+Documentation not found
+"""
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
     clean_up::Ptr{aws_log_formatter_clean_up_fn}
 end
 
+"""
+    aws_log_formatter
+
+Log formatter interface and default implementation
+
+Log formatters are invoked by the LOGF\\_* macros to transform a set of arguments into one or more lines of text to be output to a logging sink (writer).
+"""
 struct aws_log_formatter
     vtable::Ptr{aws_log_formatter_vtable}
     allocator::Ptr{aws_allocator}
     impl::Ptr{Cvoid}
 end
 
+"""
+    aws_log_formatter_standard_options
+
+Documentation not found
+"""
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
 end
@@ -7182,6 +7612,11 @@ You can filter both dynamically (by setting the log level on the logger object) 
     AWS_LL_COUNT = 7
 end
 
+"""
+    aws_logging_standard_formatting_data
+
+Documentation not found
+"""
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
     total_length::Csize_t
@@ -7196,6 +7631,10 @@ end
 """
     aws_log_formatter_init_default(formatter, allocator, options)
 
+Initializes the default log formatter which outputs lines in the format:
+
+[<LogLevel>] [<Timestamp>] [<ThreadId>] - <User content>
+
 ### Prototype
 ```c
 int aws_log_formatter_init_default( struct aws_log_formatter *formatter, struct aws_allocator *allocator, struct aws_log_formatter_standard_options *options);
@@ -7208,6 +7647,8 @@ end
 """
     aws_log_formatter_clean_up(formatter)
 
+Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean\\_up function via the vtable.
+
 ### Prototype
 ```c
 void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
@@ -7217,6 +7658,11 @@ function aws_log_formatter_clean_up(formatter)
     ccall((:aws_log_formatter_clean_up, libaws_c_common), Cvoid, (Ptr{aws_log_formatter},), formatter)
 end
 
+"""
+    aws_log_writer_file_options
+
+Documentation not found
+"""
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
     file::Ptr{Libc.FILE}
@@ -7224,6 +7670,8 @@ end
 
 """
     aws_log_writer_init_stdout(writer, allocator)
+
+Initialize a log writer that sends log lines to stdout. Uses C library IO.
 
 ### Prototype
 ```c
@@ -7237,6 +7685,8 @@ end
 """
     aws_log_writer_init_stderr(writer, allocator)
 
+Initialize a log writer that sends log lines to stderr. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator);
@@ -7249,6 +7699,8 @@ end
 """
     aws_log_writer_init_file(writer, allocator, options)
 
+Initialize a log writer that sends log lines to a file. Uses C library IO.
+
 ### Prototype
 ```c
 int aws_log_writer_init_file( struct aws_log_writer *writer, struct aws_allocator *allocator, struct aws_log_writer_file_options *options);
@@ -7260,6 +7712,8 @@ end
 
 """
     aws_log_writer_clean_up(writer)
+
+Frees all resources used by a log writer with the exception of the base structure memory
 
 ### Prototype
 ```c
@@ -7300,6 +7754,11 @@ function Base.setproperty!(x::Ptr{aws_logger_vtable}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_logger
+
+Documentation not found
+"""
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
     allocator::Ptr{aws_allocator}
@@ -7331,21 +7790,41 @@ Log subject is an enum similar to aws error: each library has its own value-spac
 """
 const aws_log_subject_t = UInt32
 
+"""
+    __JL_Ctag_200
+
+Each library gets space for 2^^10 log subject entries
+"""
 @cenum __JL_Ctag_200::UInt32 begin
     AWS_LOG_SUBJECT_STRIDE_BITS = 10
 end
 
+"""
+    aws_log_subject_info
+
+Documentation not found
+"""
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
     subject_name::Ptr{Cchar}
     subject_description::Ptr{Cchar}
 end
 
+"""
+    aws_log_subject_info_list
+
+Documentation not found
+"""
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
     count::Csize_t
 end
 
+"""
+    aws_common_log_subject
+
+Documentation not found
+"""
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
     AWS_LS_COMMON_TASK_SCHEDULER = 1
@@ -7359,6 +7838,13 @@ end
     AWS_LS_COMMON_LAST = 1023
 end
 
+"""
+    aws_logger_pipeline
+
+Standard logger implementation composing three sub-components:
+
+The formatter takes var args input from the user and produces a formatted log line The writer takes a formatted log line and outputs it somewhere The channel is the transport between the two
+"""
 struct aws_logger_pipeline
     formatter::Ptr{aws_log_formatter}
     channel::Ptr{aws_log_channel}
@@ -7474,6 +7960,9 @@ function aws_string_to_log_level(level_string, log_level)
     ccall((:aws_string_to_log_level, libaws_c_common), Cint, (Ptr{Cchar}, Ptr{aws_log_level}), level_string, log_level)
 end
 
+"""
+Documentation not found
+"""
 const aws_thread_id_t = Culong
 
 """
@@ -7535,6 +8024,8 @@ end
 """
     aws_logger_init_standard(logger, allocator, options)
 
+Initializes a pipeline logger that is built from the default formatter, a background thread-based channel, and a file writer. The default logger in almost all circumstances.
+
 ### Prototype
 ```c
 int aws_logger_init_standard( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_logger_standard_options *options);
@@ -7547,6 +8038,8 @@ end
 """
     aws_logger_init_from_external(logger, allocator, formatter, channel, writer, level)
 
+Initializes a pipeline logger from components that have already been initialized. This is not an ownership transfer. After the pipeline logger is cleaned up, the components will have to manually be cleaned up by the user.
+
 ### Prototype
 ```c
 int aws_logger_init_from_external( struct aws_logger *logger, struct aws_allocator *allocator, struct aws_log_formatter *formatter, struct aws_log_channel *channel, struct aws_log_writer *writer, enum aws_log_level level);
@@ -7558,6 +8051,8 @@ end
 
 """
     aws_logger_init_noalloc(logger, allocator, options)
+
+Initializes a logger that does not perform any allocation during logging. Log lines larger than the internal constant are truncated. Formatting matches the standard logger. Used for memory tracing logging. If no file or filename is set in the [`aws_logger_standard_options`](@ref), then it will use stderr.
 
 ### Prototype
 ```c
@@ -7610,12 +8105,26 @@ function aws_lru_cache_get_mru_element(cache)
     ccall((:aws_lru_cache_get_mru_element, libaws_c_common), Ptr{Cvoid}, (Ptr{aws_cache},), cache)
 end
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
+"""
+Documentation not found
+"""
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
+"""
+    __JL_Ctag_208
+
+Documentation not found
+"""
 @cenum __JL_Ctag_208::UInt32 begin
     AWS_CACHE_LINE = 64
 end
@@ -7691,14 +8200,27 @@ function aws_mutex_unlock(mutex)
 end
 
 # typedef int ( aws_priority_queue_compare_fn ) ( const void * a , const void * b )
+"""
+The comparator should return a positive value if the second argument has a higher priority than the first; Otherwise, it should return a negative value or zero. NOTE: priority\\_queue pops its highest priority element first. For example: int cmp(const void *a, const void *b) { return a < b; } would result in a max heap, while: int cmp(const void *a, const void *b) { return a > b; } would result in a min heap.
+"""
 const aws_priority_queue_compare_fn = Cvoid
 
+"""
+    aws_priority_queue
+
+Documentation not found
+"""
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
     container::aws_array_list
     backpointers::aws_array_list
 end
 
+"""
+    aws_priority_queue_node
+
+Documentation not found
+"""
 struct aws_priority_queue_node
     current_index::Csize_t
 end
@@ -7955,12 +8477,22 @@ function aws_priority_queue_node_is_in_queue(node)
     ccall((:aws_priority_queue_node_is_in_queue, libaws_c_common), Bool, (Ptr{aws_priority_queue_node},), node)
 end
 
+"""
+    aws_run_command_result
+
+Documentation not found
+"""
 struct aws_run_command_result
     ret_code::Cint
     std_out::Ptr{aws_string}
     std_err::Ptr{aws_string}
 end
 
+"""
+    aws_run_command_options
+
+Documentation not found
+"""
 struct aws_run_command_options
     command::Ptr{Cchar}
 end
@@ -8028,6 +8560,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8040,6 +8573,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8063,10 +8597,15 @@ function aws_run_command(allocator, options, result)
     ccall((:aws_run_command, libaws_c_common), Cint, (Ptr{aws_allocator}, Ptr{aws_run_command_options}, Ptr{aws_run_command_result}), allocator, options, result)
 end
 
+"""
+Standard promise interface. Promise can be waited on by multiple threads, and as long as it is ref-counted correctly, will provide the resultant value/error code to all waiters. All promise API calls are internally thread-safe.
+"""
 mutable struct aws_promise end
 
 """
     aws_promise_new(allocator)
+
+Creates a new promise
 
 ### Prototype
 ```c
@@ -8080,6 +8619,8 @@ end
 """
     aws_promise_acquire(promise)
 
+Indicate a new reference to a promise. At minimum, each new thread making use of the promise should acquire it.
+
 ### Prototype
 ```c
 struct aws_promise *aws_promise_acquire(struct aws_promise *promise);
@@ -8091,6 +8632,8 @@ end
 
 """
     aws_promise_release(promise)
+
+Releases a reference on the promise. When the refcount hits 0, the promise is cleaned up and freed.
 
 ### Prototype
 ```c
@@ -8104,6 +8647,8 @@ end
 """
     aws_promise_wait(promise)
 
+Waits infinitely for the promise to be completed
+
 ### Prototype
 ```c
 void aws_promise_wait(struct aws_promise *promise);
@@ -8115,6 +8660,8 @@ end
 
 """
     aws_promise_wait_for(promise, nanoseconds)
+
+Waits for the requested time in nanoseconds. Returns true if the promise was completed.
 
 ### Prototype
 ```c
@@ -8128,6 +8675,8 @@ end
 """
     aws_promise_complete(promise, value, dtor)
 
+Completes the promise and stores the result along with an optional destructor. If the value is not taken via [`aws_promise_take_value`](@ref), it will be destroyed when the promise's reference count reaches zero. NOTE: Promise cannot be completed twice
+
 ### Prototype
 ```c
 void aws_promise_complete(struct aws_promise *promise, void *value, void (*dtor)(void *));
@@ -8139,6 +8688,8 @@ end
 
 """
     aws_promise_fail(promise, error_code)
+
+Completes the promise and stores the error code NOTE: Promise cannot be completed twice
 
 ### Prototype
 ```c
@@ -8152,6 +8703,8 @@ end
 """
     aws_promise_is_complete(promise)
 
+Returns whether or not the promise has completed (regardless of success or failure)
+
 ### Prototype
 ```c
 bool aws_promise_is_complete(struct aws_promise *promise);
@@ -8163,6 +8716,8 @@ end
 
 """
     aws_promise_error_code(promise)
+
+Returns the error code recorded if the promise failed, or 0 if it succeeded NOTE: It is fatal to attempt to retrieve the error code before the promise is completed
 
 ### Prototype
 ```c
@@ -8176,6 +8731,8 @@ end
 """
     aws_promise_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The ownership of the value is retained by the promise. NOTE: It is fatal to attempt to retrieve the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_value(struct aws_promise *promise);
@@ -8188,6 +8745,8 @@ end
 """
     aws_promise_take_value(promise)
 
+Returns the value provided to the promise if it succeeded, or NULL if none was provided or the promise failed. Check [`aws_promise_error_code`](@ref) to be sure. NOTE: The promise relinquishes ownership of the value, the caller is now responsible for freeing any resources associated with the value NOTE: It is fatal to attempt to take the value before the promise is completed
+
 ### Prototype
 ```c
 void *aws_promise_take_value(struct aws_promise *promise);
@@ -8198,14 +8757,27 @@ function aws_promise_take_value(promise)
 end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
+"""
+Documentation not found
+"""
 const aws_simple_completion_callback = Cvoid
 
+"""
+    aws_ref_count
+
+A utility type for making ref-counted types, reminiscent of std::shared\\_ptr in C++
+"""
 struct aws_ref_count
     ref_count::aws_atomic_var
     object::Ptr{Cvoid}
     on_zero_fn::Ptr{aws_simple_completion_callback}
 end
 
+"""
+    aws_shutdown_callback_options
+
+Documentation not found
+"""
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
     shutdown_callback_user_data::Ptr{Cvoid}
@@ -8296,6 +8868,8 @@ end
 
 """
     aws_ring_buffer_check_atomic_ptr(ring_buf, atomic_ptr)
+
+Checks whether atomic\\_ptr correctly points to a memory location within the bounds of the [`aws_ring_buffer`](@ref)
 
 ### Prototype
 ```c
@@ -8404,6 +8978,11 @@ function aws_ring_buffer_buf_belongs_to_pool(ring_buffer, buf)
     ccall((:aws_ring_buffer_buf_belongs_to_pool, libaws_c_common), Bool, (Ptr{aws_ring_buffer}, Ptr{aws_byte_buf}), ring_buffer, buf)
 end
 
+"""
+    aws_rw_lock
+
+Documentation not found
+"""
 struct aws_rw_lock
     lock_handle::Ptr{Cvoid}
 end
@@ -8453,6 +9032,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -8479,6 +9059,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -8505,6 +9086,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -8514,8 +9096,16 @@ function aws_rw_lock_wunlock(lock)
     ccall((:aws_rw_lock_wunlock, libaws_c_common), Cint, (Ptr{aws_rw_lock},), lock)
 end
 
+"""
+Documentation not found
+"""
 const aws_crt_statistics_category_t = UInt32
 
+"""
+    __JL_Ctag_272
+
+Each library gets space for 2^^8 category entries
+"""
 @cenum __JL_Ctag_272::UInt32 begin
     AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS = 8
 end
@@ -8553,12 +9143,21 @@ struct aws_crt_statistics_sample_interval
 end
 
 # typedef void ( aws_crt_statistics_handler_process_statistics_fn ) ( struct aws_crt_statistics_handler * handler , struct aws_crt_statistics_sample_interval * interval , struct aws_array_list * stats , void * context )
+"""
+Statistics intake function. The array\\_list is a list of pointers to [`aws_crt_statistics_base`](@ref) "derived" (via pattern) objects. The handler should iterate the list and downcast elements whose RTTI category it understands, while skipping those it does not understand.
+"""
 const aws_crt_statistics_handler_process_statistics_fn = Cvoid
 
 # typedef void ( aws_crt_statistics_handler_destroy_fn ) ( struct aws_crt_statistics_handler * handler )
+"""
+Destroys a statistics handler implementation
+"""
 const aws_crt_statistics_handler_destroy_fn = Cvoid
 
 # typedef uint64_t ( aws_crt_statistics_handler_get_report_interval_ms_fn ) ( struct aws_crt_statistics_handler * )
+"""
+The period, in milliseconds, that the handler would like to be informed of statistics. Statistics generators are not required to honor this value, but should if able.
+"""
 const aws_crt_statistics_handler_get_report_interval_ms_fn = Cvoid
 
 """
@@ -8636,6 +9235,11 @@ end
 """
 const aws_off_t = Int64
 
+"""
+    aws_wstring
+
+Documentation not found
+"""
 struct aws_wstring
     allocator::Ptr{aws_allocator}
     len::Csize_t
@@ -8921,6 +9525,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9130,17 +9735,30 @@ function aws_secure_strlen(str, max_read_len, str_len)
     ccall((:aws_secure_strlen, libaws_c_common), Cint, (Ptr{Cchar}, Csize_t, Ptr{Csize_t}), str, max_read_len, str_len)
 end
 
+"""
+    aws_platform_os
+
+Documentation not found
+"""
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
     AWS_PLATFORM_OS_MAC = 1
     AWS_PLATFORM_OS_UNIX = 2
 end
 
+"""
+    aws_cpu_info
+
+Documentation not found
+"""
 struct aws_cpu_info
     cpu_id::Int32
     suspected_hyper_thread::Bool
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_system_environment end
 
 """
@@ -9162,6 +9780,7 @@ end
 """
     aws_system_environment_acquire(env)
 
+Documentation not found
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9174,6 +9793,7 @@ end
 """
     aws_system_environment_release(env)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -9246,6 +9866,8 @@ end
 """
     aws_get_platform_build_os()
 
+Returns the OS this was built under
+
 ### Prototype
 ```c
 enum aws_platform_os aws_get_platform_build_os(void);
@@ -9257,6 +9879,8 @@ end
 
 """
     aws_system_info_processor_count()
+
+Returns the number of online processors available for usage.
 
 ### Prototype
 ```c
@@ -9312,6 +9936,8 @@ end
 """
     aws_is_debugger_present()
 
+Returns true if a debugger is currently attached to the process.
+
 ### Prototype
 ```c
 bool aws_is_debugger_present(void);
@@ -9323,6 +9949,8 @@ end
 
 """
     aws_debug_break()
+
+If a debugger is attached to the process, trip a breakpoint.
 
 ### Prototype
 ```c
@@ -9336,6 +9964,8 @@ end
 """
     aws_backtrace(stack_frames, num_frames)
 
+Records a stack trace from the call site. Returns the number of stack entries/stack depth captured, or 0 if the operation is not supported on this platform
+
 ### Prototype
 ```c
 size_t aws_backtrace(void **stack_frames, size_t num_frames);
@@ -9348,6 +9978,8 @@ end
 """
     aws_backtrace_symbols(stack_frames, stack_depth)
 
+Converts stack frame pointers to symbols, if symbols are available Returns an array up to stack\\_depth long, that needs to be free()ed. stack\\_depth should be the length of frames. Returns NULL if the platform does not support stack frame translation or an error occurs
+
 ### Prototype
 ```c
 char **aws_backtrace_symbols(void *const *stack_frames, size_t stack_depth);
@@ -9359,6 +9991,8 @@ end
 
 """
     aws_backtrace_addr2line(stack_frames, stack_depth)
+
+Converts stack frame pointers to symbols, using all available system tools to try to produce a human readable result. This call will not be quick, as it shells out to addr2line or similar tools. On Windows, this is the same as [`aws_backtrace_symbols`](@ref)() Returns an array up to stack\\_depth long that needs to be free()ed. Missing frames will be NULL. Returns NULL if the platform does not support stack frame translation or an error occurs
 
 ### Prototype
 ```c
@@ -9386,6 +10020,8 @@ end
 """
     aws_backtrace_log(log_level)
 
+Log the callstack from the current stack to the currently configured [`aws_logger`](@ref)
+
 ### Prototype
 ```c
 void aws_backtrace_log(int log_level);
@@ -9395,6 +10031,11 @@ function aws_backtrace_log(log_level)
     ccall((:aws_backtrace_log, libaws_c_common), Cvoid, (Cint,), log_level)
 end
 
+"""
+    aws_memory_usage_stats
+
+Documentation not found
+"""
 struct aws_memory_usage_stats
     maxrss::Csize_t
     page_faults::Csize_t
@@ -9403,6 +10044,8 @@ end
 
 """
     aws_init_memory_usage_for_current_process(memory_usage)
+
+Get memory usage for current process. Raises AWS\\_ERROR\\_SYS\\_CALL\\_FAILURE on failure.
 
 ### Prototype
 ```c
@@ -9413,6 +10056,11 @@ function aws_init_memory_usage_for_current_process(memory_usage)
     ccall((:aws_init_memory_usage_for_current_process, libaws_c_common), Cint, (Ptr{aws_memory_usage_stats},), memory_usage)
 end
 
+"""
+    aws_task_status
+
+Documentation not found
+"""
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
     AWS_TASK_STATUS_CANCELED = 1
@@ -9424,6 +10072,11 @@ A scheduled function.
 """
 const aws_task_fn = Cvoid
 
+"""
+    __JL_Ctag_479
+
+honor the ABI compat
+"""
 struct __JL_Ctag_479
     data::NTuple{8, UInt8}
 end
@@ -9445,6 +10098,11 @@ function Base.setproperty!(x::Ptr{__JL_Ctag_479}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task
+
+A task object. Once added to the scheduler, a task must remain in memory until its function is executed.
+"""
 struct aws_task
     data::NTuple{64, UInt8}
 end
@@ -9471,6 +10129,11 @@ function Base.setproperty!(x::Ptr{aws_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_task_scheduler
+
+Documentation not found
+"""
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
     timed_queue::aws_priority_queue
@@ -9494,6 +10157,8 @@ end
 
 """
     aws_task_run(task, status)
+
+Runs or cancels a task
 
 ### Prototype
 ```c
@@ -9535,6 +10200,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -9630,6 +10296,11 @@ function aws_task_status_to_c_str(status)
     ccall((:aws_task_status_to_c_str, libaws_c_common), Ptr{Cchar}, (aws_task_status,), status)
 end
 
+"""
+    aws_thread_detach_state
+
+Documentation not found
+"""
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
     AWS_THREAD_JOINABLE = 2
@@ -9657,6 +10328,11 @@ Currently, only event loop group async cleanup and host resolver threads partici
     AWS_TJS_MANAGED = 1
 end
 
+"""
+    aws_thread_options
+
+Documentation not found
+"""
 struct aws_thread_options
     stack_size::Csize_t
     cpu_id::Int32
@@ -9664,6 +10340,11 @@ struct aws_thread_options
     name::aws_byte_cursor
 end
 
+"""
+    aws_thread_once
+
+Documentation not found
+"""
 struct aws_thread_once
     data::NTuple{8, UInt8}
 end
@@ -9684,6 +10365,11 @@ function Base.setproperty!(x::Ptr{aws_thread_once}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+"""
+    aws_thread
+
+Documentation not found
+"""
 struct aws_thread
     allocator::Ptr{aws_allocator}
     detach_state::aws_thread_detach_state
@@ -9708,6 +10394,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -9880,6 +10567,9 @@ function aws_thread_current_sleep(nanos)
 end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
+"""
+Documentation not found
+"""
 const aws_thread_atexit_fn = Cvoid
 
 """
@@ -9956,6 +10646,9 @@ function aws_thread_name(allocator, thread_id, out_name)
     ccall((:aws_thread_name, libaws_c_common), Cint, (Ptr{aws_allocator}, aws_thread_id_t, Ptr{Ptr{aws_string}}), allocator, thread_id, out_name)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_thread_scheduler end
 
 """
@@ -10166,6 +10859,7 @@ end
 """
     aws_uri_clean_up(uri)
 
+Documentation not found
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -10379,10 +11073,20 @@ function aws_byte_buf_append_decoding_uri(buffer, cursor)
     ccall((:aws_byte_buf_append_decoding_uri, libaws_c_common), Cint, (Ptr{aws_byte_buf}, Ptr{aws_byte_cursor}), buffer, cursor)
 end
 
+"""
+    aws_uuid
+
+Documentation not found
+"""
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
 end
 
+"""
+    __JL_Ctag_344
+
+36 bytes for the UUID plus one more for the null terminator.
+"""
 @cenum __JL_Ctag_344::UInt32 begin
     AWS_UUID_STR_LEN = 37
 end
@@ -10390,6 +11094,7 @@ end
 """
     aws_uuid_init(uuid)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -10402,6 +11107,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -10414,6 +11120,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
+Documentation not found
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -10426,6 +11133,7 @@ end
 """
     aws_uuid_equals(a, b)
 
+Documentation not found
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -10435,8 +11143,16 @@ function aws_uuid_equals(a, b)
     ccall((:aws_uuid_equals, libaws_c_common), Bool, (Ptr{aws_uuid}, Ptr{aws_uuid}), a, b)
 end
 
+"""
+Documentation not found
+"""
 mutable struct aws_xml_node end
 
+"""
+    aws_xml_attribute
+
+Documentation not found
+"""
 struct aws_xml_attribute
     name::aws_byte_cursor
     value::aws_byte_cursor
@@ -10454,6 +11170,11 @@ return true to continue the parsing operation.
 """
 const aws_xml_parser_on_node_encountered_fn = Cvoid
 
+"""
+    aws_xml_parser_options
+
+Documentation not found
+"""
 struct aws_xml_parser_options
     doc::aws_byte_cursor
     max_depth::Csize_t
@@ -10506,6 +11227,8 @@ end
 """
     aws_xml_node_get_name(node)
 
+Get the name of an xml node.
+
 ### Prototype
 ```c
 struct aws_byte_cursor aws_xml_node_get_name(const struct aws_xml_node *node);
@@ -10518,6 +11241,8 @@ end
 """
     aws_xml_node_get_num_attributes(node)
 
+Get the number of attributes for an xml node.
+
 ### Prototype
 ```c
 size_t aws_xml_node_get_num_attributes(const struct aws_xml_node *node);
@@ -10529,6 +11254,8 @@ end
 
 """
     aws_xml_node_get_attribute(node, attribute_index)
+
+Get an attribute for an xml node by its index.
 
 ### Prototype
 ```c
@@ -10746,14 +11473,28 @@ describes the type of context metadata
 end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
+"""
+Documentation not found
+"""
 const aws_test_after_fn = Cvoid
 
+"""
+    aws_test_harness
+
+Documentation not found
+"""
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
     run::Ptr{aws_test_run_fn}
@@ -10766,6 +11507,7 @@ end
 """
     s_aws_run_test_case(harness)
 
+Documentation not found
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -10778,6 +11520,7 @@ end
 """
     s_test_print_stack_trace(exception_pointers)
 
+Documentation not found
 ### Prototype
 ```c
 static LONG WINAPI s_test_print_stack_trace(struct _EXCEPTION_POINTERS *exception_pointers);
@@ -10790,6 +11533,7 @@ end
 """
     enable_vt_mode()
 
+Documentation not found
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -10799,38 +11543,86 @@ function enable_vt_mode()
     ccall((:enable_vt_mode, libaws_c_common), Cint, ())
 end
 
+"""
+Documentation not found
+"""
 const AWS_OP_SUCCESS = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = NULL , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_OP_ERR = -1
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
+"""
+Documentation not found
+"""
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM = Cchar('\\')
 
+"""
+Documentation not found
+"""
 const AWS_PATH_DELIM_STR = "\\"
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_NONE = 0
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_FATAL = 1
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_ERROR = 2
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_WARN = 3
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_INFO = 4
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_DEBUG = 5
 
+"""
+Documentation not found
+"""
 const AWS_LOG_LEVEL_TRACE = 6
 
+"""
+Documentation not found
+"""
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_FORCE_INLINE __attribute__ ( ( always_inline ) )
@@ -10839,18 +11631,39 @@ const PRInSTR = "%.*s"
 
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
+"""
+Documentation not found
+"""
 const SIZE_BITS = 64
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = NULL , . initialized = true }
 
+"""
+Documentation not found
+"""
 const AWS_PACKAGE_SLOTS = 16
 
+"""
+Documentation not found
+"""
 const AWS_C_COMMON_PACKAGE_ID = 0
 
+"""
+Documentation not found
+"""
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = NULL }
 
+"""
+Documentation not found
+"""
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
+"""
+Documentation not found
+"""
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: AWS_THREAD_ID_T_REPR_BUFSZ ( sizeof ( aws_thread_id_t ) * 2 + 1 )
@@ -10859,15 +11672,33 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
 # Skipping MacroDefinition: ITT_INLINE static __inline__ __attribute__ ( ( __always_inline__ , __gnu_inline__ ) )
 
+"""
+Documentation not found
+"""
 const AWS_OP_SKIP = -2
 
+"""
+Documentation not found
+"""
 const AWS_TESTING_REPORT_FD = stderr
 
+"""
+Documentation not found
+"""
 const FAIL_PREFIX = "***FAILURE*** "
 
+"""
+Documentation not found
+"""
 const SUCCESS = 0
 
+"""
+Documentation not found
+"""
 const FAILURE = -1
 
+"""
+Documentation not found
+"""
 const SKIP = 103
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,19 +1,19 @@
 using CEnum
 
 """
-Documentation not found
+Documentation not found.
 """
 const __time64_t = Clonglong
 
 """
-Documentation not found
+Documentation not found.
 """
 const time_t = __time64_t
 
 """
     tm
 
-Documentation not found
+Documentation not found.
 """
 struct tm
     data::NTuple{36, UInt8}
@@ -44,7 +44,7 @@ function Base.setproperty!(x::Ptr{tm}, f::Symbol, v)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const LONG = Clong
 
@@ -78,7 +78,7 @@ end
 """
     aws_default_allocator()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_allocator *aws_default_allocator(void);
@@ -482,7 +482,7 @@ end
 """
     aws_clz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i32(int32_t n);
@@ -495,7 +495,7 @@ end
 """
     aws_clz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_u64(uint64_t n);
@@ -508,7 +508,7 @@ end
 """
     aws_clz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_i64(int64_t n);
@@ -521,7 +521,7 @@ end
 """
     aws_clz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_clz_size(size_t n);
@@ -548,7 +548,7 @@ end
 """
     aws_ctz_i32(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i32(int32_t n);
@@ -561,7 +561,7 @@ end
 """
     aws_ctz_u64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_u64(uint64_t n);
@@ -574,7 +574,7 @@ end
 """
     aws_ctz_i64(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_i64(int64_t n);
@@ -587,7 +587,7 @@ end
 """
     aws_ctz_size(n)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
@@ -768,7 +768,7 @@ end
 """
     aws_min_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_min_u8(uint8_t a, uint8_t b);
@@ -781,7 +781,7 @@ end
 """
     aws_max_u8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint8_t aws_max_u8(uint8_t a, uint8_t b);
@@ -794,7 +794,7 @@ end
 """
     aws_min_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_min_i8(int8_t a, int8_t b);
@@ -807,7 +807,7 @@ end
 """
     aws_max_i8(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int8_t aws_max_i8(int8_t a, int8_t b);
@@ -820,7 +820,7 @@ end
 """
     aws_min_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_min_u16(uint16_t a, uint16_t b);
@@ -833,7 +833,7 @@ end
 """
     aws_max_u16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint16_t aws_max_u16(uint16_t a, uint16_t b);
@@ -846,7 +846,7 @@ end
 """
     aws_min_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_min_i16(int16_t a, int16_t b);
@@ -859,7 +859,7 @@ end
 """
     aws_max_i16(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int16_t aws_max_i16(int16_t a, int16_t b);
@@ -872,7 +872,7 @@ end
 """
     aws_min_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_min_u32(uint32_t a, uint32_t b);
@@ -885,7 +885,7 @@ end
 """
     aws_max_u32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint32_t aws_max_u32(uint32_t a, uint32_t b);
@@ -898,7 +898,7 @@ end
 """
     aws_min_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_min_i32(int32_t a, int32_t b);
@@ -911,7 +911,7 @@ end
 """
     aws_max_i32(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int32_t aws_max_i32(int32_t a, int32_t b);
@@ -924,7 +924,7 @@ end
 """
     aws_min_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_min_u64(uint64_t a, uint64_t b);
@@ -937,7 +937,7 @@ end
 """
     aws_max_u64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL uint64_t aws_max_u64(uint64_t a, uint64_t b);
@@ -950,7 +950,7 @@ end
 """
     aws_min_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_min_i64(int64_t a, int64_t b);
@@ -963,7 +963,7 @@ end
 """
     aws_max_i64(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int64_t aws_max_i64(int64_t a, int64_t b);
@@ -976,7 +976,7 @@ end
 """
     aws_min_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_min_size(size_t a, size_t b);
@@ -989,7 +989,7 @@ end
 """
     aws_max_size(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL size_t aws_max_size(size_t a, size_t b);
@@ -1002,7 +1002,7 @@ end
 """
     aws_min_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_min_int(int a, int b);
@@ -1015,7 +1015,7 @@ end
 """
     aws_max_int(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL int aws_max_int(int a, int b);
@@ -1028,7 +1028,7 @@ end
 """
     aws_min_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_min_float(float a, float b);
@@ -1041,7 +1041,7 @@ end
 """
     aws_max_float(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL float aws_max_float(float a, float b);
@@ -1054,7 +1054,7 @@ end
 """
     aws_min_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_min_double(double a, double b);
@@ -1067,7 +1067,7 @@ end
 """
     aws_max_double(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL double aws_max_double(double a, double b);
@@ -1080,7 +1080,7 @@ end
 """
     __JL_Ctag_15
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_15::UInt32 begin
     AWS_ARRAY_LIST_DEBUG_FILL = 221
@@ -1089,7 +1089,7 @@ end
 """
     aws_array_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_array_list
     alloc::Ptr{aws_allocator}
@@ -1478,7 +1478,7 @@ end
 """
     aws_fatal_assert(cond_str, file, line)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_fatal_assert(const char *cond_str, const char *file, int line) AWS_ATTRIBUTE_NORETURN;
@@ -1489,7 +1489,7 @@ function aws_fatal_assert(cond_str, file, line)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_atomic_impl_int_t = Csize_t
 
@@ -1930,7 +1930,7 @@ end
 """
     aws_atomic_priv_xlate_order(order)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int aws_atomic_priv_xlate_order(enum aws_memory_order order);
@@ -2187,7 +2187,7 @@ end
 """
     aws_byte_buf_init(buf, allocator, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator, size_t capacity);
@@ -2284,7 +2284,7 @@ end
 """
     aws_byte_buf_clean_up(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf);
@@ -2911,7 +2911,7 @@ end
 """
     aws_byte_buf_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_array(const void *bytes, size_t len);
@@ -2924,7 +2924,7 @@ end
 """
     aws_byte_buf_from_empty_array(bytes, capacity)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_buf aws_byte_buf_from_empty_array(const void *bytes, size_t capacity);
@@ -2937,7 +2937,7 @@ end
 """
     aws_byte_cursor_from_buf(buf)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_buf(const struct aws_byte_buf *const buf);
@@ -2950,7 +2950,7 @@ end
 """
     aws_byte_cursor_from_c_str(c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_c_str(const char *c_str);
@@ -2963,7 +2963,7 @@ end
 """
     aws_byte_cursor_from_array(bytes, len)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_byte_cursor aws_byte_cursor_from_array(const void *const bytes, const size_t len);
@@ -3494,7 +3494,7 @@ end
 """
     aws_linked_list_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list_node
     next::Ptr{aws_linked_list_node}
@@ -3518,7 +3518,7 @@ end
 """
     aws_linked_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_linked_list
     head::aws_linked_list_node
@@ -3838,7 +3838,7 @@ end
 """
     aws_linked_list_swap_contents(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 AWS_STATIC_IMPL void aws_linked_list_swap_contents( struct aws_linked_list *AWS_RESTRICT a, struct aws_linked_list *AWS_RESTRICT b);
@@ -3883,7 +3883,7 @@ end
 """
     aws_cache_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cache_vtable
     destroy::Ptr{Cvoid}
@@ -3914,7 +3914,7 @@ mutable struct hash_table_state end
 """
     aws_hash_table
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_table
     p_impl::Ptr{hash_table_state}
@@ -3975,7 +3975,7 @@ end
 """
     aws_cache_base_default_find(cache, key, p_value)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_find(struct aws_cache *cache, const void *key, void **p_value);
@@ -3988,7 +3988,7 @@ end
 """
     aws_cache_base_default_remove(cache, key)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_cache_base_default_remove(struct aws_cache *cache, const void *key);
@@ -4001,7 +4001,7 @@ end
 """
     aws_cache_base_default_clear(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_cache_base_default_clear(struct aws_cache *cache);
@@ -4014,7 +4014,7 @@ end
 """
     aws_cache_base_default_get_element_count(cache)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 size_t aws_cache_base_default_get_element_count(const struct aws_cache *cache);
@@ -4113,7 +4113,7 @@ end
 """
     aws_timestamp_unit
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_timestamp_unit::UInt32 begin
     AWS_TIMESTAMP_SECS = 1
@@ -4181,7 +4181,7 @@ end
 """
     aws_cli_options_has_arg
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cli_options_has_arg::UInt32 begin
     AWS_CLI_OPTIONS_NO_ARGUMENT = 0
@@ -4258,13 +4258,13 @@ end
 
 Dispatches the current command line arguments with a subcommand from the second input argument in argv[], if dispatch table contains a command that matches the argument. When the command is dispatched, argc and argv will be updated to reflect the new argument count. The cli options are required to come after the subcommand. If either, no dispatch was found or there was no argument passed to the program, this function will return [`AWS_OP_ERR`](@ref). Check [`aws_last_error`](@ref)() for details on the error.
 
-### Parameters
+# Arguments
 * `argc`: number of arguments passed to int main()
 * `argv`: the arguments passed to int main()
 * `parse_cb,`: optional, specify NULL if you don't want to handle this. This argument is for parsing "meta" commands from the command line options prior to dispatch occurring.
 * `dispatch_table`: table containing functions and command name to dispatch on.
 * `table_length`: number of entries in dispatch\\_table.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref)(0) on success, [`AWS_OP_ERR`](@ref)(-1) on failure
 ### Prototype
 ```c
@@ -4306,7 +4306,7 @@ end
 """
     aws_common_fatal_assert_library_initialized()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_common_fatal_assert_library_initialized(void);
@@ -4318,14 +4318,14 @@ end
 
 # typedef bool ( aws_condition_predicate_fn ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_condition_predicate_fn = Cvoid
 
 """
     aws_condition_variable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_condition_variable
     condition_handle::Ptr{Cvoid}
@@ -4391,7 +4391,7 @@ end
 """
     aws_mutex
 
-Documentation not found
+Documentation not found.
 """
 struct aws_mutex
     mutex_handle::Ptr{Cvoid}
@@ -4457,7 +4457,7 @@ end
 """
     aws_cpu_feature_name
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_cpu_feature_name::UInt32 begin
     AWS_CPU_FEATURE_CLMUL = 0
@@ -4486,7 +4486,7 @@ function aws_cpu_has_feature(feature_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_cross_process_lock end
 
@@ -4523,7 +4523,7 @@ end
 """
     __JL_Ctag_93
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_93::UInt32 begin
     AWS_DATE_TIME_STR_MAX_LEN = 100
@@ -4533,7 +4533,7 @@ end
 """
     aws_date_format
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_format::UInt32 begin
     AWS_DATE_FORMAT_RFC822 = 0
@@ -4545,7 +4545,7 @@ end
 """
     aws_date_month
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_month::UInt32 begin
     AWS_DATE_MONTH_JANUARY = 0
@@ -4565,7 +4565,7 @@ end
 """
     aws_date_day_of_week
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_date_day_of_week::UInt32 begin
     AWS_DATE_DAY_OF_WEEK_SUNDAY = 0
@@ -4580,7 +4580,7 @@ end
 """
     aws_date_time
 
-Documentation not found
+Documentation not found.
 """
 struct aws_date_time
     data::NTuple{96, UInt8}
@@ -4744,7 +4744,7 @@ end
 """
     aws_date_time_as_epoch_secs(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 double aws_date_time_as_epoch_secs(const struct aws_date_time *dt);
@@ -4757,7 +4757,7 @@ end
 """
     aws_date_time_as_nanos(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_nanos(const struct aws_date_time *dt);
@@ -4770,7 +4770,7 @@ end
 """
     aws_date_time_as_millis(dt)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_date_time_as_millis(const struct aws_date_time *dt);
@@ -4783,7 +4783,7 @@ end
 """
     aws_date_time_year(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint16_t aws_date_time_year(const struct aws_date_time *dt, bool local_time);
@@ -4796,7 +4796,7 @@ end
 """
     aws_date_time_month(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_month aws_date_time_month(const struct aws_date_time *dt, bool local_time);
@@ -4809,7 +4809,7 @@ end
 """
     aws_date_time_month_day(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_month_day(const struct aws_date_time *dt, bool local_time);
@@ -4822,7 +4822,7 @@ end
 """
     aws_date_time_day_of_week(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 enum aws_date_day_of_week aws_date_time_day_of_week(const struct aws_date_time *dt, bool local_time);
@@ -4835,7 +4835,7 @@ end
 """
     aws_date_time_hour(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_hour(const struct aws_date_time *dt, bool local_time);
@@ -4848,7 +4848,7 @@ end
 """
     aws_date_time_minute(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_minute(const struct aws_date_time *dt, bool local_time);
@@ -4861,7 +4861,7 @@ end
 """
     aws_date_time_second(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint8_t aws_date_time_second(const struct aws_date_time *dt, bool local_time);
@@ -4874,7 +4874,7 @@ end
 """
     aws_date_time_dst(dt, local_time)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_date_time_dst(const struct aws_date_time *dt, bool local_time);
@@ -5223,7 +5223,7 @@ end
 """
     aws_text_encoding
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_text_encoding::UInt32 begin
     AWS_TEXT_UNKNOWN = 0
@@ -5264,7 +5264,7 @@ end
 """
     aws_utf8_decoder_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_utf8_decoder_options
     on_codepoint::Ptr{Cvoid}
@@ -5276,10 +5276,10 @@ end
 
 Decode a complete string of UTF8/ASCII text. Text is always validated according to RFC-3629 (you may perform additional validation in the on\\_codepoint callback). The text does not need to begin with a UTF8 BOM. If you need to decode text incrementally as you receive it, use [`aws_utf8_decoder_new`](@ref)() instead.
 
-### Parameters
+# Arguments
 * `bytes`: Text to decode.
 * `options`: Options for decoding. If NULL is passed, the text is simply validated.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if successful. An error is raised if the text is not valid, or the on\\_codepoint callback raises an error.
 ### Prototype
 ```c
@@ -5291,7 +5291,7 @@ function aws_decode_utf8(bytes, options)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_utf8_decoder end
 
@@ -5302,7 +5302,7 @@ Create a UTF8/ASCII decoder, which can process text incrementally as you receive
 
 Feed bytes into the decoder with [`aws_utf8_decoder_update`](@ref)(), and call [`aws_utf8_decoder_finalize`](@ref)() when the text is complete.
 
-### Parameters
+# Arguments
 * `allocator`: Allocator
 * `options`: Options for decoder. If NULL is passed, the text is simply validated.
 ### Prototype
@@ -5317,7 +5317,7 @@ end
 """
     aws_utf8_decoder_destroy(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_destroy(struct aws_utf8_decoder *decoder);
@@ -5330,7 +5330,7 @@ end
 """
     aws_utf8_decoder_reset(decoder)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_utf8_decoder_reset(struct aws_utf8_decoder *decoder);
@@ -5373,7 +5373,7 @@ end
 """
     aws_string
 
-Documentation not found
+Documentation not found.
 """
 struct aws_string
     allocator::Ptr{aws_allocator}
@@ -5426,7 +5426,7 @@ end
 """
     aws_error_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info
     error_code::Cint
@@ -5439,7 +5439,7 @@ end
 """
     aws_error_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_error_info_list
     error_list::Ptr{aws_error_info}
@@ -5448,7 +5448,7 @@ end
 
 # typedef void ( aws_error_handler_fn ) ( int err , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_error_handler_fn = Cvoid
 
@@ -5609,7 +5609,7 @@ end
 """
     aws_unregister_error_info(error_info)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_unregister_error_info(const struct aws_error_info_list *error_info);
@@ -5650,7 +5650,7 @@ end
 """
     aws_common_error
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_error::UInt32 begin
     AWS_ERROR_SUCCESS = 0
@@ -5747,14 +5747,14 @@ function aws_cache_new_fifo(allocator, hash_fn, equals_fn, destroy_key_fn, destr
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_directory_iterator end
 
 """
     aws_file_type
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_file_type::UInt32 begin
     AWS_FILE_TYPE_FILE = 1
@@ -5765,7 +5765,7 @@ end
 """
     aws_directory_entry
 
-Documentation not found
+Documentation not found.
 """
 struct aws_directory_entry
     path::aws_byte_cursor
@@ -6005,7 +6005,7 @@ end
 
 Normalizes the path by replacing any directory separator with the local platform's directory separator.
 
-### Parameters
+# Arguments
 * `path`: path to normalize. Must be writeable.
 ### Prototype
 ```c
@@ -6083,7 +6083,7 @@ end
 """
     __JL_Ctag_143
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_143::UInt32 begin
     AWS_COMMON_HASH_TABLE_ITER_CONTINUE = 1
@@ -6106,7 +6106,7 @@ end
 """
     aws_hash_iter_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_hash_iter_status::UInt32 begin
     AWS_HASH_ITER_STATUS_DONE = 0
@@ -6117,7 +6117,7 @@ end
 """
     aws_hash_iter
 
-Documentation not found
+Documentation not found.
 """
 struct aws_hash_iter
     map::Ptr{aws_hash_table}
@@ -6243,7 +6243,7 @@ Updates iterator so that it points to next element of hash table.
 
 This and the two previous functions are designed to be used together with the following idiom:
 
-for (struct [`aws_hash_iter`](@ref) iter = [`aws_hash_iter_begin`](@ref)(&map); ![`aws_hash_iter_done`](@ref)(&iter); [`aws_hash_iter_next`](@ref)(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }
+`for (struct aws_hash_iter iter = aws_hash_iter_begin(&map); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) { const key\\_type key = *(const key\\_type *)iter.element.key; value\\_type value = *(value\\_type *)iter.element.value; // etc. }`
 
 Note that calling this on an iter which is "done" is idempotent: i.e. it will return another iter which is "done".
 
@@ -6261,7 +6261,7 @@ end
 
 Deletes the element currently pointed-to by the hash iterator. After calling this method, the element member of the iterator should not be accessed until the next call to [`aws_hash_iter_next`](@ref).
 
-### Parameters
+# Arguments
 * `destroy_contents`: If true, the destructors for the key and value will be called.
 ### Prototype
 ```c
@@ -6473,7 +6473,7 @@ end
 """
     aws_hash_combine(item1, item2)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 uint64_t aws_hash_combine(uint64_t item1, uint64_t item2);
@@ -6568,7 +6568,7 @@ function aws_hash_iter_is_valid(iter)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_json_value end
 
@@ -6579,10 +6579,10 @@ Creates a new string [`aws_json_value`](@ref) with the given string and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `string`: A byte pointer to the string you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new string [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6600,10 +6600,10 @@ Creates a new number [`aws_json_value`](@ref) with the given number and returns 
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `number`: The number you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new number [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6621,9 +6621,9 @@ Creates a new array [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this array will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new array [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6641,10 +6641,10 @@ Creates a new boolean [`aws_json_value`](@ref) with the given boolean and return
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `boolean`: The boolean you want to store in the [`aws_json_value`](@ref)
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new boolean [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6662,9 +6662,9 @@ Creates a new null [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new null [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6682,9 +6682,9 @@ Creates a new object [`aws_json_value`](@ref) and returns a pointer to it.
 
 Note: You will need to free the memory for the [`aws_json_value`](@ref) using aws\\_json\\_destroy on the [`aws_json_value`](@ref) or on the object/array containing the [`aws_json_value`](@ref). Deleting this object will also destroy any aws\\_json\\_values it contains.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator to use when creating the value
-### Returns
+# Returns
 A new object [`aws_json_value`](@ref)
 ### Prototype
 ```c
@@ -6700,10 +6700,10 @@ end
 
 Gets the string of a string [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The string [`aws_json_value`](@ref).
 * `output`: The string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a string, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6719,10 +6719,10 @@ end
 
 Gets the number of a number [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The number [`aws_json_value`](@ref).
 * `output`: The number
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a number, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6738,10 +6738,10 @@ end
 
 Gets the boolean of a boolean [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The boolean [`aws_json_value`](@ref).
 * `output`: The boolean
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the value is a boolean, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
 ```c
@@ -6759,11 +6759,11 @@ Adds a [`aws_json_value`](@ref) to a object [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) object is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to add a value to.
 * `key`: The key to add the [`aws_json_value`](@ref) at.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding was successful. Will return AWS\\_OP\\_ERROR if the object passed is invalid or if the passed key is already in use in the object.
 ### Prototype
 ```c
@@ -6779,10 +6779,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to get the value from.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 The [`aws_json_value`](@ref) at the given key, otherwise NULL.
 ### Prototype
 ```c
@@ -6798,10 +6798,10 @@ end
 
 Checks if there is a [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The value [`aws_json_value`](@ref) you want to check a key in.
 * `key`: The key that you want to check. Is case sensitive.
-### Returns
+# Returns
 True if a [`aws_json_value`](@ref) is found.
 ### Prototype
 ```c
@@ -6817,10 +6817,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given key.
 
-### Parameters
+# Arguments
 * `object`: The object [`aws_json_value`](@ref) you want to remove a [`aws_json_value`](@ref) in.
 * `key`: The key that the [`aws_json_value`](@ref) is at. Is case sensitive.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) was removed. Will return [`AWS_OP_ERR`](@ref) if the object passed is invalid or if the value at the key cannot be found.
 ### Prototype
 ```c
@@ -6842,11 +6842,11 @@ const aws_json_on_member_encountered_const_fn = Cvoid
 
 iterates through members of the object. iteration is sequential in order fields were initially parsed.
 
-### Parameters
+# Arguments
 * `object`: object to iterate over.
 * `on_member`: callback for when member is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an object.
 ### Prototype
 ```c
@@ -6864,10 +6864,10 @@ Adds a [`aws_json_value`](@ref) to the given array [`aws_json_value`](@ref).
 
 Note that the [`aws_json_value`](@ref) will be destroyed when the [`aws_json_value`](@ref) array is destroyed by calling "aws\\_json\\_destroy()"
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref) you want to add an [`aws_json_value`](@ref) to.
 * `value`: The [`aws_json_value`](@ref) you want to add.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if adding the [`aws_json_value`](@ref) was successful. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid.
 ### Prototype
 ```c
@@ -6883,10 +6883,10 @@ end
 
 Returns the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index of the [`aws_json_value`](@ref) you want to access.
-### Returns
+# Returns
 A pointer to the [`aws_json_value`](@ref) at the given index in the array, otherwise NULL.
 ### Prototype
 ```c
@@ -6902,9 +6902,9 @@ end
 
 Returns the number of items in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
-### Returns
+# Returns
 The number of items in the array\\_json\\_value.
 ### Prototype
 ```c
@@ -6920,10 +6920,10 @@ end
 
 Removes the [`aws_json_value`](@ref) at the given index in the array [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `array`: The array [`aws_json_value`](@ref).
 * `index`: The index containing the [`aws_json_value`](@ref) you want to remove.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the [`aws_json_value`](@ref) at the index was removed. Will return [`AWS_OP_ERR`](@ref) if the array passed is invalid or if the index passed is out of range.
 ### Prototype
 ```c
@@ -6945,11 +6945,11 @@ const aws_json_on_value_encountered_const_fn = Cvoid
 
 iterates through values of an array. iteration is sequential starting with 0th element.
 
-### Parameters
+# Arguments
 * `array`: array to iterate over.
 * `on_value`: callback for when value is encountered.
 * `user_data`: user data to pass back in callback.
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) when iteration finishes completely or exits early, [`AWS_OP_ERR`](@ref) if value is not an array.
 ### Prototype
 ```c
@@ -6965,11 +6965,11 @@ end
 
 Checks whether two json values are equivalent.
 
-### Parameters
+# Arguments
 * `a`: first value to compare.
 * `b`: second value to compare.
 * `is_case_sensitive`: case sensitive compare or not.
-### Returns
+# Returns
 True is values are equal, false otherwise
 ### Prototype
 ```c
@@ -6985,9 +6985,9 @@ end
 
 Duplicates json value.
 
-### Parameters
+# Arguments
 * `value`: first value to compare.
-### Returns
+# Returns
 duplicated value. NULL and last error set if value cannot be duplicated.
 ### Prototype
 ```c
@@ -7003,9 +7003,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a string.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a string [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7021,9 +7021,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a number.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a number [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7039,9 +7039,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a array.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a array [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7057,9 +7057,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a boolean.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a boolean [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7075,9 +7075,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a null [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7093,9 +7093,9 @@ end
 
 Checks if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref).
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to check.
-### Returns
+# Returns
 True if the [`aws_json_value`](@ref) is a object [`aws_json_value`](@ref), otherwise false.
 ### Prototype
 ```c
@@ -7113,7 +7113,7 @@ Removes the [`aws_json_value`](@ref) from memory. If the [`aws_json_value`](@ref
 
 For example, if you called "aws\\_json\\_array\\_add(b, a)" to add an object "a" to an array "b", if you call "aws\\_json\\_destroy(b)" then it will also free "a" automatically. All children/attached aws\\_json\\_values are freed when the parent/root [`aws_json_value`](@ref) is destroyed.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to destroy.
 ### Prototype
 ```c
@@ -7133,10 +7133,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there was an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7156,10 +7156,10 @@ Note: The byte buffer will automatically have its size extended if the JSON stri
 
 Note: When you are finished with the [`aws_byte_buf`](@ref), you must call "[`aws_byte_buf_clean_up_secure`](@ref)" to free the memory used, as it will NOT be called automatically.
 
-### Parameters
+# Arguments
 * `value`: The [`aws_json_value`](@ref) to format.
 * `output`: The destination for the JSON string
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the JSON string was allocated to output without any errors Will return [`AWS_OP_ERR`](@ref) if the value passed is not an [`aws_json_value`](@ref) or if there aws an error appending the JSON into the byte buffer.
 ### Prototype
 ```c
@@ -7175,10 +7175,10 @@ end
 
 Parses the JSON string and returns a [`aws_json_value`](@ref) containing the root of the JSON.
 
-### Parameters
+# Arguments
 * `allocator`: The allocator used to create the value
 * `string`: The string containing the JSON.
-### Returns
+# Returns
 The root [`aws_json_value`](@ref) of the JSON.
 ### Prototype
 ```c
@@ -7352,7 +7352,7 @@ end
 
 returns the underlying linked list for iteration.
 
-The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use [`AWS_CONTAINER_OF`](@ref) for access to the element.
+The returned list has nodes of the type: [`aws_linked_hash_table_node`](@ref). Use `AWS_CONTAINER_OF` for access to the element.
 
 ### Prototype
 ```c
@@ -7435,20 +7435,20 @@ end
 
 # typedef int ( aws_log_channel_send_fn ) ( struct aws_log_channel * channel , struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_send_fn = Cvoid
 
 # typedef void ( aws_log_channel_clean_up_fn ) ( struct aws_log_channel * channel )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_channel_clean_up_fn = Cvoid
 
 """
     aws_log_channel_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_channel_vtable
     send::Ptr{aws_log_channel_send_fn}
@@ -7457,20 +7457,20 @@ end
 
 # typedef int ( aws_log_writer_write_fn ) ( struct aws_log_writer * writer , const struct aws_string * output )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_write_fn = Cvoid
 
 # typedef void ( aws_log_writer_clean_up_fn ) ( struct aws_log_writer * writer )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_writer_clean_up_fn = Cvoid
 
 """
     aws_log_writer_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_vtable
     write::Ptr{aws_log_writer_write_fn}
@@ -7552,20 +7552,20 @@ end
 
 # typedef int ( aws_log_formatter_format_fn ) ( struct aws_log_formatter * formatter , struct aws_string * * formatted_output , enum aws_log_level level , aws_log_subject_t subject , const char * format , va_list args )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_format_fn = Cvoid
 
 # typedef void ( aws_log_formatter_clean_up_fn ) ( struct aws_log_formatter * logger )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_log_formatter_clean_up_fn = Cvoid
 
 """
     aws_log_formatter_vtable
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_vtable
     format::Ptr{aws_log_formatter_format_fn}
@@ -7588,7 +7588,7 @@ end
 """
     aws_log_formatter_standard_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_formatter_standard_options
     date_format::aws_date_format
@@ -7615,7 +7615,7 @@ end
 """
     aws_logging_standard_formatting_data
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logging_standard_formatting_data
     log_line_buffer::Ptr{Cchar}
@@ -7661,7 +7661,7 @@ end
 """
     aws_log_writer_file_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_writer_file_options
     filename::Ptr{Cchar}
@@ -7757,7 +7757,7 @@ end
 """
     aws_logger
 
-Documentation not found
+Documentation not found.
 """
 struct aws_logger
     vtable::Ptr{aws_logger_vtable}
@@ -7802,7 +7802,7 @@ end
 """
     aws_log_subject_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info
     subject_id::aws_log_subject_t
@@ -7813,7 +7813,7 @@ end
 """
     aws_log_subject_info_list
 
-Documentation not found
+Documentation not found.
 """
 struct aws_log_subject_info_list
     subject_list::Ptr{aws_log_subject_info}
@@ -7823,7 +7823,7 @@ end
 """
     aws_common_log_subject
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_common_log_subject::UInt32 begin
     AWS_LS_COMMON_GENERAL = 0
@@ -7883,10 +7883,10 @@ end
 
 Gets the aws logger used globally across the process if the logging level is at least the inputted level.
 
-### Parameters
+# Arguments
 * `subject`: log subject to perform the level check versus, not currently used
 * `level`: logging level to check against in order to return the logger
-### Returns
+# Returns
 the current logger if the current logging level is at or more detailed then the supplied logging level
 ### Prototype
 ```c
@@ -7916,10 +7916,10 @@ end
 
 Sets the current logging level for the logger. Loggers are not require to support this.
 
-### Parameters
+# Arguments
 * `logger`: logger to set the log level for
 * `level`: new log level for the logger
-### Returns
+# Returns
 [`AWS_OP_SUCCESS`](@ref) if the level was successfully set, [`AWS_OP_ERR`](@ref) otherwise
 ### Prototype
 ```c
@@ -7961,7 +7961,7 @@ function aws_string_to_log_level(level_string, log_level)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_id_t = Culong
 
@@ -8106,24 +8106,24 @@ function aws_lru_cache_get_mru_element(cache)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_60 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_61 = NTuple{1, Cchar}
 
 """
-Documentation not found
+Documentation not found.
 """
 const static_assertion_at_line_62 = NTuple{1, Cchar}
 
 """
     __JL_Ctag_208
 
-Documentation not found
+Documentation not found.
 """
 @cenum __JL_Ctag_208::UInt32 begin
     AWS_CACHE_LINE = 64
@@ -8208,7 +8208,7 @@ const aws_priority_queue_compare_fn = Cvoid
 """
     aws_priority_queue
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue
     pred::Ptr{aws_priority_queue_compare_fn}
@@ -8219,7 +8219,7 @@ end
 """
     aws_priority_queue_node
 
-Documentation not found
+Documentation not found.
 """
 struct aws_priority_queue_node
     current_index::Csize_t
@@ -8448,7 +8448,7 @@ end
 
 Initializes a queue node to a default value that indicates the node is not in the queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to initialize with a default value
 ### Prototype
 ```c
@@ -8464,9 +8464,9 @@ end
 
 Checks if a priority queue node is currently in a priority queue.
 
-### Parameters
+# Arguments
 * `node`: priority queue node to check usage for
-### Returns
+# Returns
 true if the node is in a queue, false otherwise
 ### Prototype
 ```c
@@ -8480,7 +8480,7 @@ end
 """
     aws_run_command_result
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_result
     ret_code::Cint
@@ -8491,7 +8491,7 @@ end
 """
     aws_run_command_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_run_command_options
     command::Ptr{Cchar}
@@ -8502,7 +8502,7 @@ end
 
 Returns the current process's PID (process id).
 
-### Returns
+# Returns
 PID as int
 ### Prototype
 ```c
@@ -8560,7 +8560,7 @@ end
 """
     aws_run_command_result_init(allocator, result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_run_command_result_init(struct aws_allocator *allocator, struct aws_run_command_result *result);
@@ -8573,7 +8573,7 @@ end
 """
     aws_run_command_result_cleanup(result)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_run_command_result_cleanup(struct aws_run_command_result *result);
@@ -8758,7 +8758,7 @@ end
 
 # typedef void ( aws_simple_completion_callback ) ( void * )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_simple_completion_callback = Cvoid
 
@@ -8776,7 +8776,7 @@ end
 """
     aws_shutdown_callback_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_shutdown_callback_options
     shutdown_callback_fn::Ptr{aws_simple_completion_callback}
@@ -8788,7 +8788,7 @@ end
 
 Initializes a ref-counter structure. After initialization, the ref count will be 1.
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to initialize
 * `object`: object being ref counted
 * `on_zero_fn`: function to invoke when the ref count reaches zero
@@ -8806,9 +8806,9 @@ end
 
 Increments a ref-counter's ref count
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to increment the count for
-### Returns
+# Returns
 the object being ref-counted
 ### Prototype
 ```c
@@ -8824,9 +8824,9 @@ end
 
 Decrements a ref-counter's ref count. Invokes the on\\_zero callback if the ref count drops to zero
 
-### Parameters
+# Arguments
 * `ref_count`: ref-counter to decrement the count for
-### Returns
+# Returns
 the value of the decremented ref count
 ### Prototype
 ```c
@@ -8981,7 +8981,7 @@ end
 """
     aws_rw_lock
 
-Documentation not found
+Documentation not found.
 """
 struct aws_rw_lock
     lock_handle::Ptr{Cvoid}
@@ -9032,7 +9032,7 @@ end
 """
     aws_rw_lock_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wlock(struct aws_rw_lock *lock);
@@ -9059,7 +9059,7 @@ end
 """
     aws_rw_lock_try_wlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_try_wlock(struct aws_rw_lock *lock);
@@ -9086,7 +9086,7 @@ end
 """
     aws_rw_lock_wunlock(lock)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_rw_lock_wunlock(struct aws_rw_lock *lock);
@@ -9097,7 +9097,7 @@ function aws_rw_lock_wunlock(lock)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const aws_crt_statistics_category_t = UInt32
 
@@ -9231,14 +9231,16 @@ function aws_crt_statistics_handler_destroy(handler)
 end
 
 """
-\\deprecated Use int64\\_t instead for offsets in public APIs.
+!!! compat "Deprecated"
+
+    Use int64\\_t instead for offsets in public APIs.
 """
 const aws_off_t = Int64
 
 """
     aws_wstring
 
-Documentation not found
+Documentation not found.
 """
 struct aws_wstring
     allocator::Ptr{aws_allocator}
@@ -9525,7 +9527,7 @@ end
 """
     aws_string_eq_c_str(str, c_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_string_eq_c_str(const struct aws_string *str, const char *c_str);
@@ -9636,7 +9638,7 @@ end
 """
     aws_string_destroy_secure(str)
 
-Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with [`AWS_STATIC_STRING_FROM_LITERAL`](@ref).
+Zeroes out the data bytes of string and then deallocates the memory. Not safe to run on a string created with `AWS_STATIC_STRING_FROM_LITERAL`.
 
 ### Prototype
 ```c
@@ -9738,7 +9740,7 @@ end
 """
     aws_platform_os
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_platform_os::UInt32 begin
     AWS_PLATFORM_OS_WINDOWS = 0
@@ -9749,7 +9751,7 @@ end
 """
     aws_cpu_info
 
-Documentation not found
+Documentation not found.
 """
 struct aws_cpu_info
     cpu_id::Int32
@@ -9757,7 +9759,7 @@ struct aws_cpu_info
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_system_environment end
 
@@ -9780,7 +9782,7 @@ end
 """
     aws_system_environment_acquire(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 struct aws_system_environment *aws_system_environment_acquire(struct aws_system_environment *env);
@@ -9793,7 +9795,7 @@ end
 """
     aws_system_environment_release(env)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_system_environment_release(struct aws_system_environment *env);
@@ -10034,7 +10036,7 @@ end
 """
     aws_memory_usage_stats
 
-Documentation not found
+Documentation not found.
 """
 struct aws_memory_usage_stats
     maxrss::Csize_t
@@ -10059,7 +10061,7 @@ end
 """
     aws_task_status
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_task_status::UInt32 begin
     AWS_TASK_STATUS_RUN_READY = 0
@@ -10073,28 +10075,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    __JL_Ctag_479
+    __JL_Ctag_492
 
 honor the ABI compat
 """
-struct __JL_Ctag_479
+struct __JL_Ctag_492
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_479}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_492}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_479, f::Symbol)
-    r = Ref{__JL_Ctag_479}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_479}, r)
+function Base.getproperty(x::__JL_Ctag_492, f::Symbol)
+    r = Ref{__JL_Ctag_492}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_492}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_479}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_492}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10114,7 +10116,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{__JL_Ctag_479}(x + 56)
+    f === :abi_extension && return Ptr{__JL_Ctag_492}(x + 56)
     return getfield(x, f)
 end
 
@@ -10132,7 +10134,7 @@ end
 """
     aws_task_scheduler
 
-Documentation not found
+Documentation not found.
 """
 struct aws_task_scheduler
     alloc::Ptr{aws_allocator}
@@ -10200,7 +10202,7 @@ end
 """
     aws_task_scheduler_is_valid(scheduler)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_task_scheduler_is_valid(const struct aws_task_scheduler *scheduler);
@@ -10299,7 +10301,7 @@ end
 """
     aws_thread_detach_state
 
-Documentation not found
+Documentation not found.
 """
 @cenum aws_thread_detach_state::UInt32 begin
     AWS_THREAD_NOT_CREATED = 1
@@ -10331,7 +10333,7 @@ end
 """
     aws_thread_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_options
     stack_size::Csize_t
@@ -10343,7 +10345,7 @@ end
 """
     aws_thread_once
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread_once
     data::NTuple{8, UInt8}
@@ -10368,7 +10370,7 @@ end
 """
     aws_thread
 
-Documentation not found
+Documentation not found.
 """
 struct aws_thread
     allocator::Ptr{aws_allocator}
@@ -10394,7 +10396,7 @@ end
 """
     aws_thread_call_once(flag, call_once, user_data)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_thread_call_once(aws_thread_once *flag, void (*call_once)(void *), void *user_data);
@@ -10568,7 +10570,7 @@ end
 
 # typedef void ( aws_thread_atexit_fn ) ( void * user_data )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_thread_atexit_fn = Cvoid
 
@@ -10647,7 +10649,7 @@ function aws_thread_name(allocator, thread_id, out_name)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_thread_scheduler end
 
@@ -10859,7 +10861,7 @@ end
 """
     aws_uri_clean_up(uri)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 void aws_uri_clean_up(struct aws_uri *uri);
@@ -11076,7 +11078,7 @@ end
 """
     aws_uuid
 
-Documentation not found
+Documentation not found.
 """
 struct aws_uuid
     uuid_data::NTuple{16, UInt8}
@@ -11094,7 +11096,7 @@ end
 """
     aws_uuid_init(uuid)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init(struct aws_uuid *uuid);
@@ -11107,7 +11109,7 @@ end
 """
     aws_uuid_init_from_str(uuid, uuid_str)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_init_from_str(struct aws_uuid *uuid, const struct aws_byte_cursor *uuid_str);
@@ -11120,7 +11122,7 @@ end
 """
     aws_uuid_to_str(uuid, output)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
@@ -11133,7 +11135,7 @@ end
 """
     aws_uuid_equals(a, b)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 bool aws_uuid_equals(const struct aws_uuid *a, const struct aws_uuid *b);
@@ -11144,14 +11146,14 @@ function aws_uuid_equals(a, b)
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 mutable struct aws_xml_node end
 
 """
     aws_xml_attribute
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_attribute
     name::aws_byte_cursor
@@ -11173,7 +11175,7 @@ const aws_xml_parser_on_node_encountered_fn = Cvoid
 """
     aws_xml_parser_options
 
-Documentation not found
+Documentation not found.
 """
 struct aws_xml_parser_options
     doc::aws_byte_cursor
@@ -11474,26 +11476,26 @@ end
 
 # typedef int ( aws_test_before_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_before_fn = Cvoid
 
 # typedef int ( aws_test_run_fn ) ( struct aws_allocator * allocator , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_run_fn = Cvoid
 
 # typedef int ( aws_test_after_fn ) ( struct aws_allocator * allocator , int setup_result , void * ctx )
 """
-Documentation not found
+Documentation not found.
 """
 const aws_test_after_fn = Cvoid
 
 """
     aws_test_harness
 
-Documentation not found
+Documentation not found.
 """
 struct aws_test_harness
     on_before::Ptr{aws_test_before_fn}
@@ -11507,7 +11509,7 @@ end
 """
     s_aws_run_test_case(harness)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int s_aws_run_test_case(struct aws_test_harness *harness);
@@ -11520,7 +11522,7 @@ end
 """
     s_test_print_stack_trace(exception_pointers)
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static LONG WINAPI s_test_print_stack_trace(struct _EXCEPTION_POINTERS *exception_pointers);
@@ -11533,7 +11535,7 @@ end
 """
     enable_vt_mode()
 
-Documentation not found
+Documentation not found.
 ### Prototype
 ```c
 static inline int enable_vt_mode(void);
@@ -11544,84 +11546,84 @@ function enable_vt_mode()
 end
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_CONDITION_VARIABLE_INIT { . condition_handle = NULL , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_ERR = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE_BITS = 10
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_ERROR_ENUM_STRIDE = Cuint(1) << AWS_ERROR_ENUM_STRIDE_BITS
 
 # Skipping MacroDefinition: AWS_STATIC_IMPL static inline
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM = Cchar('\\')
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PATH_DELIM_STR = "\\"
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_NONE = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_FATAL = 1
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_ERROR = 2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_WARN = 3
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_INFO = 4
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_DEBUG = 5
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_LEVEL_TRACE = 6
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_LOG_SUBJECT_STRIDE = Cuint(1) << AWS_LOG_SUBJECT_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const PRInSTR = "%.*s"
 
@@ -11632,37 +11634,37 @@ const PRInSTR = "%.*s"
 # Skipping MacroDefinition: AWS_ATTRIBUTE_NORETURN __attribute__ ( ( noreturn ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const SIZE_BITS = 64
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_MUTEX_INIT { . mutex_handle = NULL , . initialized = true }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_PACKAGE_SLOTS = 16
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_C_COMMON_PACKAGE_ID = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 # Skipping MacroDefinition: AWS_RW_LOCK_INIT { . lock_handle = NULL }
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_CRT_STATISTICS_CATEGORY_STRIDE = Cuint(1) << AWS_CRT_STATISTICS_CATEGORY_STRIDE_BITS
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 
@@ -11673,32 +11675,32 @@ const AWS_THREAD_NAME_RECOMMENDED_STRLEN = 15
 # Skipping MacroDefinition: ITT_INLINE static __inline__ __attribute__ ( ( __always_inline__ , __gnu_inline__ ) )
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_OP_SKIP = -2
 
 """
-Documentation not found
+Documentation not found.
 """
 const AWS_TESTING_REPORT_FD = stderr
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAIL_PREFIX = "***FAILURE*** "
 
 """
-Documentation not found
+Documentation not found.
 """
 const SUCCESS = 0
 
 """
-Documentation not found
+Documentation not found.
 """
 const FAILURE = -1
 
 """
-Documentation not found
+Documentation not found.
 """
 const SKIP = 103
 

--- a/src/LibAwsCommon.jl
+++ b/src/LibAwsCommon.jl
@@ -37,10 +37,10 @@ end
 
 # exports
 for name in names(@__MODULE__; all=true)
-    nm = string(name)
-    if startswith(nm, "aws_") || startswith(nm, "AWS_")
-        @eval export $name
+    if name == :eval || name == :include || contains(string(name), "#")
+        continue
     end
+    @eval export $name
 end
 
 end

--- a/src/LibAwsCommon.jl
+++ b/src/LibAwsCommon.jl
@@ -28,7 +28,7 @@ elseif Sys.islinux() && Sys.ARCH === :x86_64 && !IS_LIBC_MUSL
 elseif Sys.islinux() && Sys.ARCH === :x86_64 && IS_LIBC_MUSL
     include("../lib/x86_64-linux-musl.jl")
 elseif Sys.isbsd() && !Sys.isapple()
-    include("../lib/x86_64-unknown-freebsd.jl")
+    include("../lib/x86_64-unknown-freebsd13.2.jl")
 elseif Sys.iswindows() && Sys.ARCH === :x86_64
     include("../lib/x86_64-w64-mingw32.jl")
 else


### PR DESCRIPTION
This PR fixes the documentation.

This should work once the bindings are regenerated. Blocked by https://github.com/JuliaInterop/Clang.jl/issues/486

We should do this to IO as well.