### PR TITLE
Update aws_c_common_jll to version 0.12.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsCommon"
 uuid = "c6e421ba-b5f8-4792-a1c4-42948de3ed9d"
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -9,7 +9,7 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Aqua = "0.7"
 CEnum = "0.5"
-aws_c_common_jll = "=0.11.2"
+aws_c_common_jll = "=0.12.1"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -6,4 +6,4 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_common_jll = "=0.11.2"
+aws_c_common_jll = "=0.12.1"


### PR DESCRIPTION
This PR updates aws_c_common_jll to version 0.12.1. cc: @quinnj, @Octogonapus