### PR TITLE
Update aws_c_common_jll to version 0.12.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsCommon"
 uuid = "c6e421ba-b5f8-4792-a1c4-42948de3ed9d"
-version = "1.2.2"
+version = "1.2.3"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -9,7 +9,7 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Aqua = "0.7"
 CEnum = "0.5"
-aws_c_common_jll = "=0.12.1"
+aws_c_common_jll = "=0.12.2"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -6,4 +6,4 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_common_jll = "=0.12.1"
+aws_c_common_jll = "=0.12.2"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -570,118 +570,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -811,6 +699,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10760,28 +10760,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e58ab35c3247064ca9323d98663abe87c0a409c9/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e58ab35c3247064ca9323d98663abe87c0a409c9/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e58ab35c3247064ca9323d98663abe87c0a409c9/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e58ab35c3247064ca9323d98663abe87c0a409c9/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e58ab35c3247064ca9323d98663abe87c0a409c9/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e58ab35c3247064ca9323d98663abe87c0a409c9/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e58ab35c3247064ca9323d98663abe87c0a409c9/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10801,7 +10801,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e58ab35c3247064ca9323d98663abe87c0a409c9/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -547,118 +547,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -788,6 +676,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10737,28 +10737,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/80c2a315a240a34ea9bfb49a1aaa2b3435776a13/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/80c2a315a240a34ea9bfb49a1aaa2b3435776a13/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80c2a315a240a34ea9bfb49a1aaa2b3435776a13/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/80c2a315a240a34ea9bfb49a1aaa2b3435776a13/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/80c2a315a240a34ea9bfb49a1aaa2b3435776a13/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80c2a315a240a34ea9bfb49a1aaa2b3435776a13/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80c2a315a240a34ea9bfb49a1aaa2b3435776a13/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10778,7 +10778,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/80c2a315a240a34ea9bfb49a1aaa2b3435776a13/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -501,118 +501,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -742,6 +630,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10691,28 +10691,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/81261a9de92b18b5f7aa24c14928f7769cfd4134/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/81261a9de92b18b5f7aa24c14928f7769cfd4134/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81261a9de92b18b5f7aa24c14928f7769cfd4134/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81261a9de92b18b5f7aa24c14928f7769cfd4134/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81261a9de92b18b5f7aa24c14928f7769cfd4134/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81261a9de92b18b5f7aa24c14928f7769cfd4134/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81261a9de92b18b5f7aa24c14928f7769cfd4134/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10732,7 +10732,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81261a9de92b18b5f7aa24c14928f7769cfd4134/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -546,118 +546,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -787,6 +675,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10736,28 +10736,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/0c2e79a79b496c6d4569e62c7b1abd7a62a9c4f8/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/0c2e79a79b496c6d4569e62c7b1abd7a62a9c4f8/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c2e79a79b496c6d4569e62c7b1abd7a62a9c4f8/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0c2e79a79b496c6d4569e62c7b1abd7a62a9c4f8/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0c2e79a79b496c6d4569e62c7b1abd7a62a9c4f8/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c2e79a79b496c6d4569e62c7b1abd7a62a9c4f8/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c2e79a79b496c6d4569e62c7b1abd7a62a9c4f8/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10777,7 +10777,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c2e79a79b496c6d4569e62c7b1abd7a62a9c4f8/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -501,118 +501,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -742,6 +630,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10691,28 +10691,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/d9af9cfa52e8fd7e51ecff0f1b5f40059d19abc1/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/d9af9cfa52e8fd7e51ecff0f1b5f40059d19abc1/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d9af9cfa52e8fd7e51ecff0f1b5f40059d19abc1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d9af9cfa52e8fd7e51ecff0f1b5f40059d19abc1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d9af9cfa52e8fd7e51ecff0f1b5f40059d19abc1/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d9af9cfa52e8fd7e51ecff0f1b5f40059d19abc1/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d9af9cfa52e8fd7e51ecff0f1b5f40059d19abc1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10732,7 +10732,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d9af9cfa52e8fd7e51ecff0f1b5f40059d19abc1/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -551,118 +551,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -792,6 +680,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10741,28 +10741,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/47dac085509d054ee66bede765b4ff98df96716b/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/47dac085509d054ee66bede765b4ff98df96716b/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/47dac085509d054ee66bede765b4ff98df96716b/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/47dac085509d054ee66bede765b4ff98df96716b/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/47dac085509d054ee66bede765b4ff98df96716b/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/47dac085509d054ee66bede765b4ff98df96716b/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/47dac085509d054ee66bede765b4ff98df96716b/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10782,7 +10782,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/47dac085509d054ee66bede765b4ff98df96716b/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -501,118 +501,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -742,6 +630,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10691,28 +10691,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/0188eb389d57db5ff3a7a496521b6a9b9f31ace6/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/0188eb389d57db5ff3a7a496521b6a9b9f31ace6/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0188eb389d57db5ff3a7a496521b6a9b9f31ace6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0188eb389d57db5ff3a7a496521b6a9b9f31ace6/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0188eb389d57db5ff3a7a496521b6a9b9f31ace6/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0188eb389d57db5ff3a7a496521b6a9b9f31ace6/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0188eb389d57db5ff3a7a496521b6a9b9f31ace6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10732,7 +10732,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0188eb389d57db5ff3a7a496521b6a9b9f31ace6/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -547,118 +547,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -788,6 +676,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10737,28 +10737,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/dc760a2d42545002bda4cda05ae9bac58254ba5f/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/dc760a2d42545002bda4cda05ae9bac58254ba5f/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dc760a2d42545002bda4cda05ae9bac58254ba5f/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/dc760a2d42545002bda4cda05ae9bac58254ba5f/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/dc760a2d42545002bda4cda05ae9bac58254ba5f/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dc760a2d42545002bda4cda05ae9bac58254ba5f/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dc760a2d42545002bda4cda05ae9bac58254ba5f/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10778,7 +10778,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dc760a2d42545002bda4cda05ae9bac58254ba5f/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -570,118 +570,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -811,6 +699,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10760,28 +10760,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/4db8b2ca16215fc3eb703f43f39b4047d3741221/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/4db8b2ca16215fc3eb703f43f39b4047d3741221/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4db8b2ca16215fc3eb703f43f39b4047d3741221/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/4db8b2ca16215fc3eb703f43f39b4047d3741221/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/4db8b2ca16215fc3eb703f43f39b4047d3741221/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4db8b2ca16215fc3eb703f43f39b4047d3741221/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4db8b2ca16215fc3eb703f43f39b4047d3741221/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10801,7 +10801,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4db8b2ca16215fc3eb703f43f39b4047d3741221/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -551,118 +551,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -792,6 +680,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10741,28 +10741,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/d3c04159ad974d3059b28cf352c4225572527bf2/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/d3c04159ad974d3059b28cf352c4225572527bf2/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d3c04159ad974d3059b28cf352c4225572527bf2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d3c04159ad974d3059b28cf352c4225572527bf2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d3c04159ad974d3059b28cf352c4225572527bf2/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d3c04159ad974d3059b28cf352c4225572527bf2/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d3c04159ad974d3059b28cf352c4225572527bf2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10782,7 +10782,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d3c04159ad974d3059b28cf352c4225572527bf2/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -501,118 +501,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -742,6 +630,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10691,28 +10691,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/3c9dfe0a43e9cd29b32fdaeb0f973b062b7708a3/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/3c9dfe0a43e9cd29b32fdaeb0f973b062b7708a3/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c9dfe0a43e9cd29b32fdaeb0f973b062b7708a3/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3c9dfe0a43e9cd29b32fdaeb0f973b062b7708a3/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3c9dfe0a43e9cd29b32fdaeb0f973b062b7708a3/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c9dfe0a43e9cd29b32fdaeb0f973b062b7708a3/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c9dfe0a43e9cd29b32fdaeb0f973b062b7708a3/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10732,7 +10732,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3c9dfe0a43e9cd29b32fdaeb0f973b062b7708a3/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -403,118 +403,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -644,6 +532,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10593,28 +10593,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/ba8bf3cb60bc45640326ae4a0429c73cafe80181/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/ba8bf3cb60bc45640326ae4a0429c73cafe80181/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ba8bf3cb60bc45640326ae4a0429c73cafe80181/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ba8bf3cb60bc45640326ae4a0429c73cafe80181/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ba8bf3cb60bc45640326ae4a0429c73cafe80181/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ba8bf3cb60bc45640326ae4a0429c73cafe80181/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ba8bf3cb60bc45640326ae4a0429c73cafe80181/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10634,7 +10634,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ba8bf3cb60bc45640326ae4a0429c73cafe80181/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -354,118 +354,6 @@ function aws_is_mem_zeroed(buf, bufsize)
 end
 
 """
-    aws_mul_u64_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_mul_u64_saturating(a, b)
-    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_mul_u64_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_mul_u64_checked(a, b, r)
-    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_mul_u32_saturating(a, b)
-
-Multiplies a * b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_mul_u32_saturating(a, b)
-    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
-    aws_mul_u32_checked(a, b, r)
-
-If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_mul_u32_checked(a, b, r)
-    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u64_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
-```
-"""
-function aws_add_u64_checked(a, b, r)
-    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
-end
-
-"""
-    aws_add_u64_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^64 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
-```
-"""
-function aws_add_u64_saturating(a, b)
-    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
-end
-
-"""
-    aws_add_u32_checked(a, b, r)
-
-If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
-
-### Prototype
-```c
-AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
-```
-"""
-function aws_add_u32_checked(a, b, r)
-    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
-end
-
-"""
-    aws_add_u32_saturating(a, b)
-
-Adds a + b. If the result overflows, returns 2^32 - 1.
-
-### Prototype
-```c
-AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
-```
-"""
-function aws_add_u32_saturating(a, b)
-    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
-end
-
-"""
     aws_clz_u32(n)
 
 Search from the MSB to LSB, looking for a 1
@@ -595,6 +483,118 @@ AWS_STATIC_IMPL size_t aws_ctz_size(size_t n);
 """
 function aws_ctz_size(n)
     ccall((:aws_ctz_size, libaws_c_common), Csize_t, (Csize_t,), n)
+end
+
+"""
+    aws_mul_u64_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_mul_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_mul_u64_saturating(a, b)
+    ccall((:aws_mul_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_mul_u64_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_mul_u64_checked(a, b, r)
+    ccall((:aws_mul_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_mul_u32_saturating(a, b)
+
+Multiplies a * b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_mul_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_mul_u32_saturating(a, b)
+    ccall((:aws_mul_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
+end
+
+"""
+    aws_mul_u32_checked(a, b, r)
+
+If a * b overflows, returns [`AWS_OP_ERR`](@ref); otherwise multiplies a * b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_mul_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_mul_u32_checked(a, b, r)
+    ccall((:aws_mul_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u64_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u64_checked(uint64_t a, uint64_t b, uint64_t *r);
+```
+"""
+function aws_add_u64_checked(a, b, r)
+    ccall((:aws_add_u64_checked, libaws_c_common), Cint, (UInt64, UInt64, Ptr{UInt64}), a, b, r)
+end
+
+"""
+    aws_add_u64_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^64 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint64_t aws_add_u64_saturating(uint64_t a, uint64_t b);
+```
+"""
+function aws_add_u64_saturating(a, b)
+    ccall((:aws_add_u64_saturating, libaws_c_common), UInt64, (UInt64, UInt64), a, b)
+end
+
+"""
+    aws_add_u32_checked(a, b, r)
+
+If a + b overflows, returns [`AWS_OP_ERR`](@ref); otherwise adds a + b, returns the result in *r, and returns [`AWS_OP_SUCCESS`](@ref).
+
+### Prototype
+```c
+AWS_STATIC_IMPL int aws_add_u32_checked(uint32_t a, uint32_t b, uint32_t *r);
+```
+"""
+function aws_add_u32_checked(a, b, r)
+    ccall((:aws_add_u32_checked, libaws_c_common), Cint, (UInt32, UInt32, Ptr{UInt32}), a, b, r)
+end
+
+"""
+    aws_add_u32_saturating(a, b)
+
+Adds a + b. If the result overflows, returns 2^32 - 1.
+
+### Prototype
+```c
+AWS_STATIC_IMPL uint32_t aws_add_u32_saturating(uint32_t a, uint32_t b);
+```
+"""
+function aws_add_u32_saturating(a, b)
+    ccall((:aws_add_u32_saturating, libaws_c_common), UInt32, (UInt32, UInt32), a, b)
 end
 
 """
@@ -10763,28 +10763,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10804,7 +10804,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_common_jll** to version **0.12.2**
- Updated **JuliaServices/LibAwsCommon.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings