### PR TITLE
Update aws_c_common_jll to version 0.12.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsCommon"
 uuid = "c6e421ba-b5f8-4792-a1c4-42948de3ed9d"
-version = "1.2.3"
+version = "1.2.4"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -9,7 +9,7 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Aqua = "0.7"
 CEnum = "0.5"
-aws_c_common_jll = "=0.12.2"
+aws_c_common_jll = "=0.12.3"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -6,4 +6,4 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_common_jll = "=0.12.2"
+aws_c_common_jll = "=0.12.3"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -4777,6 +4777,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4966,11 +4983,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10760,28 +10777,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10801,7 +10818,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/833ac04438373e05030b7ca0e7ddbbe766346a65/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -4754,6 +4754,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4943,11 +4960,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10737,28 +10754,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10778,7 +10795,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/edb4e56076b9d98deb4e67406375139c7582bca4/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -4708,6 +4708,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4897,11 +4914,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10691,28 +10708,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10732,7 +10749,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/42a3b693d2faa53ae2093487ed449ac0c41f83aa/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -4753,6 +4753,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4942,11 +4959,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10736,28 +10753,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10777,7 +10794,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ee9751df3b1888733d1c6b93c4c3cd8e3fb5c543/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -4708,6 +4708,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4897,11 +4914,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10691,28 +10708,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10732,7 +10749,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/528c12c223b029afad463eeffce19c67eeb53785/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -4758,6 +4758,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4947,11 +4964,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10741,28 +10758,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10782,7 +10799,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35e1cc4e82164236d8d9dc4eff5324151e9d73ca/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -4708,6 +4708,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4897,11 +4914,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10691,28 +10708,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10732,7 +10749,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a96f90fabf64dacbb58a77fef95df3b57753ce90/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -4754,6 +4754,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4943,11 +4960,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10737,28 +10754,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10778,7 +10795,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1966fe2665e27ac09d4895b928d911157769502a/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -4777,6 +4777,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4966,11 +4983,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10760,28 +10777,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10801,7 +10818,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fbdfb21ba47df1920c32c92ecd519de4ed779daa/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -4758,6 +4758,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4947,11 +4964,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10741,28 +10758,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10782,7 +10799,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5980124e8b7729ec93c329f059ababc9ad0e3ce8/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -4708,6 +4708,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4897,11 +4914,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10691,28 +10708,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10732,7 +10749,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9d8244e77dd90d16fc6b0af0a78ff2819b0f14/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -4610,6 +4610,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4799,11 +4816,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10593,28 +10610,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10634,7 +10651,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/35ef76a3a16503525e92ca6f2d653563dc4bceba/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -4561,6 +4561,23 @@ function aws_cbor_decoder_get_remaining_length(decoder)
 end
 
 """
+    aws_cbor_decoder_reset_src(decoder, src)
+
+Reset the decoder source to a new src. The previous src will be discarded regardless of the unconsumed bytes. The decoder will clear its cache if any.
+
+# Arguments
+* `decoder`:
+* `src`: The src data to decode from..
+### Prototype
+```c
+void aws_cbor_decoder_reset_src(struct aws_cbor_decoder *decoder, struct aws_byte_cursor src);
+```
+"""
+function aws_cbor_decoder_reset_src(decoder, src)
+    ccall((:aws_cbor_decoder_reset_src, libaws_c_common), Cvoid, (Ptr{aws_cbor_decoder}, aws_byte_cursor), decoder, src)
+end
+
+"""
     aws_cbor_decoder_peek_type(decoder, out_type)
 
 Decode the next element and store it in the decoder cache if there was no element cached. If there was element cached, just return the type of the cached element.
@@ -4750,11 +4767,11 @@ end
 """
     aws_cbor_decoder_pop_next_tag_val(decoder, out_tag_val)
 
-Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
+Get the next AWS\\_CBOR\\_TYPE\\_TAG element. Only consume the AWS\\_CBOR\\_TYPE\\_TAG element and set the tag ID value to *out\\_tag\\_val, not the content of the tagged. The next cbor data item will be the content of the tagged value for a valid cbor data.
 
 # Arguments
 * `decoder`:
-* `out_size`: store the size of map if succeed.
+* `out_tag_val`: store the value of tag ID.
 # Returns
 [`AWS_OP_SUCCESS`](@ref) successfully consumed the next element and get the result, otherwise [`AWS_OP_ERR`](@ref).
 ### Prototype
@@ -10763,28 +10780,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10804,7 +10821,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/14b76afb08516e081cf71604d5c8c972023487e6/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_common_jll** to version **0.12.3**
- Updated **JuliaServices/LibAwsCommon.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings