### PR TITLE
Update aws_c_common_jll to version 0.12.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsCommon"
 uuid = "c6e421ba-b5f8-4792-a1c4-42948de3ed9d"
-version = "1.3.3"
+version = "1.3.4"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -9,7 +9,7 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Aqua = "0.7,0.8"
 CEnum = "0.5"
-aws_c_common_jll = "=0.12.3"
+aws_c_common_jll = "=0.12.4"
 Test = "1.11"
 julia = "1.6"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -6,4 +6,4 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_common_jll = "=0.12.3"
+aws_c_common_jll = "=0.12.4"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -10777,28 +10777,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10818,7 +10818,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 
@@ -11775,6 +11775,15 @@ end
 end
 
 """
+    __JL_Ctag_15
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_15::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11811,6 +11820,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -10754,28 +10754,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10795,7 +10795,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 
@@ -11752,6 +11752,15 @@ end
 end
 
 """
+    __JL_Ctag_167
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_167::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11788,6 +11797,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -10708,28 +10708,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10749,7 +10749,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 
@@ -11706,6 +11706,15 @@ end
 end
 
 """
+    __JL_Ctag_8
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_8::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11742,6 +11751,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -10753,28 +10753,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10794,7 +10794,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -11751,6 +11751,15 @@ end
 end
 
 """
+    __JL_Ctag_167
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_167::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11787,6 +11796,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -10708,28 +10708,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10749,7 +10749,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -11706,6 +11706,15 @@ end
 end
 
 """
+    __JL_Ctag_8
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_8::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11742,6 +11751,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -10758,28 +10758,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10799,7 +10799,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -11756,6 +11756,15 @@ end
 end
 
 """
+    __JL_Ctag_153
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_153::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11792,6 +11801,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -10708,28 +10708,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10749,7 +10749,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 
@@ -11706,6 +11706,15 @@ end
 end
 
 """
+    __JL_Ctag_8
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_8::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11742,6 +11751,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -10754,28 +10754,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10795,7 +10795,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 
@@ -11752,6 +11752,15 @@ end
 end
 
 """
+    __JL_Ctag_153
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_153::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11788,6 +11797,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -10777,28 +10777,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10818,7 +10818,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 
@@ -11775,6 +11775,15 @@ end
 end
 
 """
+    __JL_Ctag_15
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_15::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11811,6 +11820,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -10758,28 +10758,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10799,7 +10799,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1cf9acf0ab79da28402a861403d490775dbbe936/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 
@@ -11756,6 +11756,15 @@ end
 end
 
 """
+    __JL_Ctag_146
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_146::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11792,6 +11801,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -10708,28 +10708,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10749,7 +10749,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 
@@ -11706,6 +11706,15 @@ end
 end
 
 """
+    __JL_Ctag_8
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_8::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11742,6 +11751,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -10610,28 +10610,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10651,7 +10651,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 
@@ -11608,6 +11608,15 @@ end
 end
 
 """
+    __JL_Ctag_8
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_8::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11644,6 +11653,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -10780,28 +10780,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10821,7 +10821,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 
@@ -11799,6 +11799,15 @@ end
 end
 
 """
+    __JL_Ctag_8
+
+32 bytes for the UUID (no dashes) plus one more for the null terminator.
+"""
+@cenum __JL_Ctag_8::UInt32 begin
+    AWS_UUID_STR_COMPACT_LEN = 33
+end
+
+"""
     aws_uuid_init(uuid)
 
 Documentation not found.
@@ -11835,6 +11844,19 @@ int aws_uuid_to_str(const struct aws_uuid *uuid, struct aws_byte_buf *output);
 """
 function aws_uuid_to_str(uuid, output)
     ccall((:aws_uuid_to_str, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
+end
+
+"""
+    aws_uuid_to_str_compact(uuid, output)
+
+Documentation not found.
+### Prototype
+```c
+int aws_uuid_to_str_compact(const struct aws_uuid *uuid, struct aws_byte_buf *output);
+```
+"""
+function aws_uuid_to_str_compact(uuid, output)
+    ccall((:aws_uuid_to_str_compact, libaws_c_common), Cint, (Ptr{aws_uuid}, Ptr{aws_byte_buf}), uuid, output)
 end
 
 """


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_common_jll** to version **0.12.4**
- Updated **JuliaServices/LibAwsCommon.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings