### PR TITLE
Update aws_c_common_jll to version 0.12.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsCommon"
 uuid = "c6e421ba-b5f8-4792-a1c4-42948de3ed9d"
-version = "1.3.4"
+version = "1.3.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -9,7 +9,7 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Aqua = "0.7,0.8"
 CEnum = "0.5"
-aws_c_common_jll = "=0.12.4"
+aws_c_common_jll = "=0.12.5"
 Test = "1.11"
 julia = "1.6"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -6,4 +6,4 @@ aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_common_jll = "=0.12.4"
+aws_c_common_jll = "=0.12.5"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -542,6 +542,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6986,6 +7014,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_4
 
 Documentation not found.
@@ -10596,6 +10682,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10777,28 +10877,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10818,7 +10918,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -519,6 +519,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6963,6 +6991,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_49
 
 Documentation not found.
@@ -10573,6 +10659,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10754,28 +10854,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10795,7 +10895,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -473,6 +473,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6917,6 +6945,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_3
 
 Documentation not found.
@@ -10527,6 +10613,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10708,28 +10808,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10749,7 +10849,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -518,6 +518,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6962,6 +6990,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_49
 
 Documentation not found.
@@ -10572,6 +10658,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10753,28 +10853,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10794,7 +10894,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -473,6 +473,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6917,6 +6945,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_3
 
 Documentation not found.
@@ -10527,6 +10613,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10708,28 +10808,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10749,7 +10849,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -523,6 +523,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6967,6 +6995,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_43
 
 Documentation not found.
@@ -10577,6 +10663,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10758,28 +10858,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10799,7 +10899,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -473,6 +473,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6917,6 +6945,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_3
 
 Documentation not found.
@@ -10527,6 +10613,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10708,28 +10808,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10749,7 +10849,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 16)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 24)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 28)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}(x + 32)
     return getfield(x, f)
 end
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -519,6 +519,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6963,6 +6991,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_43
 
 Documentation not found.
@@ -10573,6 +10659,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10754,28 +10854,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10795,7 +10895,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -542,6 +542,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6986,6 +7014,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_4
 
 Documentation not found.
@@ -10596,6 +10682,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10777,28 +10877,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10818,7 +10918,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -523,6 +523,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6967,6 +6995,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_42
 
 Documentation not found.
@@ -10577,6 +10663,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10758,28 +10858,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/174d25bc25be346ba8b65af159f64ba02c8f5bd5/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/174d25bc25be346ba8b65af159f64ba02c8f5bd5/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/174d25bc25be346ba8b65af159f64ba02c8f5bd5/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/174d25bc25be346ba8b65af159f64ba02c8f5bd5/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/174d25bc25be346ba8b65af159f64ba02c8f5bd5/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/174d25bc25be346ba8b65af159f64ba02c8f5bd5/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/174d25bc25be346ba8b65af159f64ba02c8f5bd5/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10799,7 +10899,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e03248bd890e4921948f598caf75c76621024aa/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/174d25bc25be346ba8b65af159f64ba02c8f5bd5/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -473,6 +473,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6917,6 +6945,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_3
 
 Documentation not found.
@@ -10527,6 +10613,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10708,28 +10808,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10749,7 +10849,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -375,6 +375,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6819,6 +6847,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_3
 
 Documentation not found.
@@ -10429,6 +10515,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10610,28 +10710,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10651,7 +10751,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -326,6 +326,34 @@ function aws_small_block_allocator_page_size_available(sba_allocator)
 end
 
 """
+    aws_explicit_aligned_allocator_new(alignment)
+
+Create an aligned allocator with an explicit alignment. Always align the allocated buffer with the passed-in alignment value.
+
+### Prototype
+```c
+struct aws_allocator *aws_explicit_aligned_allocator_new(size_t alignment);
+```
+"""
+function aws_explicit_aligned_allocator_new(alignment)
+    ccall((:aws_explicit_aligned_allocator_new, libaws_c_common), Ptr{aws_allocator}, (Csize_t,), alignment)
+end
+
+"""
+    aws_explicit_aligned_allocator_destroy(aligned_alloc)
+
+Destroys a customized aligned allocator instance and frees its memory.
+
+### Prototype
+```c
+void aws_explicit_aligned_allocator_destroy(struct aws_allocator *aligned_alloc);
+```
+"""
+function aws_explicit_aligned_allocator_destroy(aligned_alloc)
+    ccall((:aws_explicit_aligned_allocator_destroy, libaws_c_common), Cvoid, (Ptr{aws_allocator},), aligned_alloc)
+end
+
+"""
     aws_raise_error(err)
 
 Raises `err` to the installed callbacks, and sets the thread's error.
@@ -6786,6 +6814,64 @@ function aws_file_get_length(file, length)
 end
 
 """
+    aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path with DIRECT I/O, starting at offset to fill the output\\_buf or to the max\\_read\\_length. Using direct IO to bypass the OS cache. Helpful when the disk I/O outperform the kernel cache. If O\\_DIRECT is not supported, returns AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION. Notes: - ONLY supports linux for now and raise AWS\\_ERROR\\_UNSUPPORTED\\_OPERATION on all other platforms (eg: FreeBSD). - check the NOTES for O\\_DIRECT in https://man7.org/linux/man-pages/man2/openat.2.html - The offset, length and output\\_buf->buffer all need to be aligned with the page size. Otherwise, AWS\\_ERROR\\_INVALID\\_ARGUMENT will be raised.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+
+Read from the file using the file path, starting at offset to fill the output\\_buf or to the max\\_read\\_length.
+
+Returns [`AWS_OP_SUCCESS`](@ref), or [`AWS_OP_ERR`](@ref) (after an error has been raised).
+
+# Arguments
+* `file_path`: The file path to read from.
+* `offset`: The offset in the file to start reading from.
+* `max_read_length`: The maximum number of bytes to read.
+* `output_buf`: The buffer read to.
+* `out_actual_read`: The actual number of bytes read.
+### Prototype
+```c
+int aws_file_path_read_from_offset( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset(file_path, offset, max_read_length, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, output_buf, out_actual_read)
+end
+
+"""
+    aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+
+The function serve the same purpose as [`aws_file_path_read_from_offset_direct_io`](@ref). Please use [`aws_file_path_read_from_offset_direct_io`](@ref) directly.
+
+### Prototype
+```c
+int aws_file_path_read_from_offset_direct_io_with_chunk_size( const struct aws_string *file_path, uint64_t offset, size_t max_read_length, size_t max_chunk_size, struct aws_byte_buf *output_buf, size_t *out_actual_read);
+```
+"""
+function aws_file_path_read_from_offset_direct_io_with_chunk_size(file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+    ccall((:aws_file_path_read_from_offset_direct_io_with_chunk_size, libaws_c_common), Cint, (Ptr{aws_string}, UInt64, Csize_t, Csize_t, Ptr{aws_byte_buf}, Ptr{Csize_t}), file_path, offset, max_read_length, max_chunk_size, output_buf, out_actual_read)
+end
+
+"""
     __JL_Ctag_3
 
 Documentation not found.
@@ -10599,6 +10685,20 @@ function aws_system_info_processor_count()
 end
 
 """
+    aws_system_info_page_size()
+
+Returns the system page size in bytes.
+
+### Prototype
+```c
+size_t aws_system_info_page_size(void);
+```
+"""
+function aws_system_info_page_size()
+    ccall((:aws_system_info_page_size, libaws_c_common), Csize_t, ())
+end
+
+"""
     aws_get_cpu_group_count()
 
 Returns the logical processor groupings on the system (such as multiple numa nodes).
@@ -10780,28 +10880,28 @@ A scheduled function.
 const aws_task_fn = Cvoid
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)
 
 honor the ABI compat
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -10821,7 +10921,7 @@ function Base.getproperty(x::Ptr{aws_task}, f::Symbol)
     f === :node && return Ptr{aws_linked_list_node}(x + 24)
     f === :priority_queue_node && return Ptr{aws_priority_queue_node}(x + 40)
     f === :type_tag && return Ptr{Ptr{Cchar}}(x + 48)
-    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
+    f === :abi_extension && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}(x + 56)
     return getfield(x, f)
 end
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_common_jll** to version **0.12.5**
- Updated **JuliaServices/LibAwsCommon.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings